### PR TITLE
Added possibility to add a period level base url.

### DIFF
--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -54,6 +54,7 @@ type MPD struct {
 }
 
 type Period struct {
+	BaseURL        string           `xml:"BaseURL,omitempty"`
 	AdaptationSets []*AdaptationSet `xml:"AdaptationSet,omitempty"`
 }
 
@@ -134,6 +135,13 @@ func NewMPD(profile DashProfile, mediaPresentationDuration string, minBufferTime
 		MinBufferTime:             Strptr(minBufferTime),
 		Period:                    &Period{},
 	}
+}
+
+// Sets a Period level base url for when the manifests and fragments are served by two different hosts.
+// baseURL - Http fragment source. (i.e. http://storage.server.com/)
+func (m *MPD) SetBaseURL(BaseURL string) *Period {
+	m.Period.BaseURL = BaseURL
+	return m.Period
 }
 
 // Create a new Adaptation Set for Audio Assets.


### PR DESCRIPTION
Period level base URLs are convenient when manifests and fragments are
served by different hosts

Fixes #8 