### PR TITLE
Start managing dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 coverage/
+vendor/
 .idea/
 \#*
 *~

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,25 @@
-GO ?= go
+GO15VENDOREXPERIMENT := 1
 COVERAGEDIR = coverage
 ifdef CIRCLE_ARTIFACTS
   COVERAGEDIR = $(CIRCLE_ARTIFACTS)
 endif
 
 all: build test cover
-build:
-	if [ ! -d bin ]; then mkdir bin; fi
-	$(GO) build -v -o bin/go-dash
 fmt:
-	$(GO) fmt ./...
+	go fmt ./...
 test:
 	if [ ! -d coverage ]; then mkdir coverage; fi
-	$(GO) test -v ./mpd -race -cover -coverprofile=$(COVERAGEDIR)/mpd.coverprofile
+	go test -v ./mpd -race -cover -coverprofile=$(COVERAGEDIR)/mpd.coverprofile
 cover:
-	$(GO) tool cover -html=$(COVERAGEDIR)/mpd.coverprofile -o $(COVERAGEDIR)/mpd.html
+	go tool cover -html=$(COVERAGEDIR)/mpd.coverprofile -o $(COVERAGEDIR)/mpd.html
 tc: test cover
 coveralls:
 	gover $(COVERAGEDIR) $(COVERAGEDIR)/coveralls.coverprofile
 	goveralls -coverprofile=$(COVERAGEDIR)/coveralls.coverprofile -service=circle-ci -repotoken=$(COVERALLS_TOKEN)
 clean:
-	$(GO) clean
-	rm -f bin/go-dash
+	go clean
 	rm -rf coverage/
 examples-live:
-	$(GO) run examples/live.go
+	go run examples/live.go
 examples-ondemand:
-	$(GO) run examples/ondemand.go
+	go run examples/ondemand.go

--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@ A Go library for generating MPEG-DASH manifests.
 
 ## Install
 
-	go get github.com/zencoder/go-dash/mpd
+This library uses [Glide](https://github.com/Masterminds/glide) to manage it's dependencies. Please refer to the Glide documentation to see how to install glide.
+
+```bash
+mkdir -p $GOPATH/zencoder
+cd $GOPATH/zencoder
+git clone https://github.com/zencoder/go-dash
+cd go-dash
+export GO15VENDOREXPERIMENT=1
+glide install
+go install ./...
+```
 
 ## Supported Features
 
@@ -45,12 +55,12 @@ make examples-ondemand
 
 ### Dependencies
 
-Tested on go 1.5.1.
+Tested on go 1.5.3.
 
 ### Build and run unit tests
 
     make test
-    
+
 ### CI
 
 [This library builds on Circle CI, here.](https://circleci.com/gh/zencoder/go-dash/)

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
+machine:
+  environment:
+    GO15VENDOREXPERIMENT: 1
 checkout:
   post:
     - rm -rf ~/.go_workspace/src/github.com/zencoder

--- a/circle.yml
+++ b/circle.yml
@@ -9,8 +9,8 @@ dependencies:
   pre:
     - sudo apt-get remove --purge golang
     - sudo rm -rf /usr/local/go/
-    - mkdir /tmp/go && wget 'https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz' -O /tmp/go/go1.5.1.linux-amd64.tar.gz
-    - sudo tar -xzf /tmp/go/go1.5.1.linux-amd64.tar.gz -C /usr/local
+    - mkdir /tmp/go && wget 'https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz' -O /tmp/go/go1.5.3.linux-amd64.tar.gz
+    - sudo tar -xzf /tmp/go/go1.5.3.linux-amd64.tar.gz -C /usr/local
   override:
     - go get github.com/tools/godep
     - go get golang.org/x/tools/cmd/cover

--- a/circle.yml
+++ b/circle.yml
@@ -11,12 +11,15 @@ dependencies:
     - sudo rm -rf /usr/local/go/
     - mkdir /tmp/go && wget 'https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz' -O /tmp/go/go1.5.3.linux-amd64.tar.gz
     - sudo tar -xzf /tmp/go/go1.5.3.linux-amd64.tar.gz -C /usr/local
+    - wget 'https://github.com/Masterminds/glide/releases/download/0.8.3/glide-0.8.3-linux-amd64.tar.gz' -O /tmp/go/glide-0.8.3-linux-amd64.tar.gz
+    - tar -xzf /tmp/go/glide-0.8.3-linux-amd64.tar.gz -C /tmp/go
+    - sudo cp /tmp/go/linux-amd64/glide /usr/local/bin/glide
   override:
-    - go get github.com/tools/godep
     - go get golang.org/x/tools/cmd/cover
     - go get github.com/mattn/goveralls
     - go get github.com/modocache/gover
     - go get github.com/stretchr/testify
+    - cd ~/.go_workspace/src/github.com/zencoder/go-dash && glide install
 test:
   override:
     - cd ~/.go_workspace/src/github.com/zencoder/go-dash && make test

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,16 @@
+hash: 828bea29d524ef5c63537cbbd2aa3776b3bc56c3a07bfe585c19f5b1a38f9b5f
+updated: 2016-02-02T11:03:27.871886427Z
+imports:
+- name: github.com/davecgh/go-spew
+  version: 2df174808ee097f90d259e432cc04442cf60be21
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/objx
+  version: cbeaeb16a013161a98496fad62933b1d21786672
+- name: github.com/stretchr/testify
+  version: f390dcf405f7b83c997eac1b06768bb9f44dec18
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,4 @@
+package: github.com/zencoder/go-dash
+import:
+  - package: github.com/stretchr/testify
+    version: ^v1.1.3


### PR DESCRIPTION
Using glide so that it's easy to manage dependency versions, fetch from internet, and doesn't require commiting vendored code.