### PR TITLE
Multi periods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,29 @@ ifdef CIRCLE_ARTIFACTS
 endif
 
 all: test cover
+
 fmt:
 	find . -not -path "./vendor/*" -name '*.go' -type f | sed 's#\(.*\)/.*#\1#' | sort -u | xargs -n1 -I {} bash -c "cd {} && goimports -w *.go && gofmt -w -s -l *.go"
+
 test:
 	if [ ! -d coverage ]; then mkdir coverage; fi
 	go test -v ./mpd -race -cover -coverprofile=$(COVERAGEDIR)/mpd.coverprofile
+
 cover:
 	go tool cover -html=$(COVERAGEDIR)/mpd.coverprofile -o $(COVERAGEDIR)/mpd.html
+
 tc: test cover
+
 coveralls:
 	gover $(COVERAGEDIR) $(COVERAGEDIR)/coveralls.coverprofile
 	goveralls -coverprofile=$(COVERAGEDIR)/coveralls.coverprofile -service=circle-ci -repotoken=$(COVERALLS_TOKEN)
+
 clean:
 	go clean
 	rm -rf coverage/
+
 examples-live:
 	go run examples/live.go
+
 examples-ondemand:
 	go run examples/ondemand.go

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ go install ./...
   * Audio
   * Video
   * Subtitles
+  * Multiple periods (multi-part playlist)
 * DRM (ContentProtection)
   * PlayReady
   * Widevine
 
 ## Known Limitations (for now) (PRs welcome)
 
-* Single Period
 * No PSSH/PRO generation
 * Limited Profile Support
 

--- a/mpd/duration.go
+++ b/mpd/duration.go
@@ -1,0 +1,128 @@
+// based on code from golang src/time/time.go
+
+package mpd
+
+import (
+	"encoding/xml"
+	"time"
+)
+
+type Duration time.Duration
+
+func (d Duration) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	return xml.Attr{name, d.String()}, nil
+}
+
+// String renders a Duration in XML Duration Data Type format
+func (d *Duration) String() string {
+	// Largest time is 2540400h10m10.000000000s
+	var buf [32]byte
+	w := len(buf)
+
+	u := uint64(*d)
+	neg := *d < 0
+	if neg {
+		u = -u
+	}
+
+	if u < uint64(time.Second) {
+		// Special case: if duration is smaller than a second,
+		// use smaller units, like 1.2ms
+		var prec int
+		w--
+		buf[w] = 'S'
+		w--
+		if u == 0 {
+			return "PT0S"
+		}
+		/*
+			switch {
+			case u < uint64(Millisecond):
+				// print microseconds
+				prec = 3
+				// U+00B5 'µ' micro sign == 0xC2 0xB5
+				w-- // Need room for two bytes.
+				copy(buf[w:], "µ")
+			default:
+				// print milliseconds
+				prec = 6
+				buf[w] = 'm'
+			}
+		*/
+		w, u = fmtFrac(buf[:w], u, prec)
+		w = fmtInt(buf[:w], u)
+	} else {
+		w--
+		buf[w] = 'S'
+
+		w, u = fmtFrac(buf[:w], u, 9)
+
+		// u is now integer seconds
+		w = fmtInt(buf[:w], u%60)
+		u /= 60
+
+		// u is now integer minutes
+		if u > 0 {
+			w--
+			buf[w] = 'M'
+			w = fmtInt(buf[:w], u%60)
+			u /= 60
+
+			// u is now integer hours
+			// Stop at hours because days can be different lengths.
+			if u > 0 {
+				w--
+				buf[w] = 'H'
+				w = fmtInt(buf[:w], u)
+			}
+		}
+	}
+
+	if neg {
+		w--
+		buf[w] = '-'
+	}
+
+	return "PT" + string(buf[w:])
+}
+
+// fmtFrac formats the fraction of v/10**prec (e.g., ".12345") into the
+// tail of buf, omitting trailing zeros.  it omits the decimal
+// point too when the fraction is 0.  It returns the index where the
+// output bytes begin and the value v/10**prec.
+func fmtFrac(buf []byte, v uint64, prec int) (nw int, nv uint64) {
+	// Omit trailing zeros up to and including decimal point.
+	w := len(buf)
+	print := false
+	for i := 0; i < prec; i++ {
+		digit := v % 10
+		print = print || digit != 0
+		if print {
+			w--
+			buf[w] = byte(digit) + '0'
+		}
+		v /= 10
+	}
+	if print {
+		w--
+		buf[w] = '.'
+	}
+	return w, v
+}
+
+// fmtInt formats v into the tail of buf.
+// It returns the index where the output begins.
+func fmtInt(buf []byte, v uint64) int {
+	w := len(buf)
+	if v == 0 {
+		w--
+		buf[w] = '0'
+	} else {
+		for v > 0 {
+			w--
+			buf[w] = byte(v%10) + '0'
+			v /= 10
+		}
+	}
+	return w
+}

--- a/mpd/duration_test.go
+++ b/mpd/duration_test.go
@@ -1,0 +1,22 @@
+package mpd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDuration(t *testing.T) {
+	in := map[string]string{
+		"0s":    "PT0S",
+		"6m16s": "PT6M16S",
+		"1.97s": "PT1.97S",
+	}
+	for ins, ex := range in {
+		timeDur, err := time.ParseDuration(ins)
+		assert.Equal(t, nil, err)
+		dur := Duration(timeDur)
+		assert.Equal(t, ex, dur.String())
+	}
+}

--- a/mpd/fixtures/hbbtv_profile.mpd
+++ b/mpd/fixtures/hbbtv_profile.mpd
@@ -11,6 +11,7 @@
         <cenc:pssh>AAACJnBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAgYGAgAAAQABAPwBPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgBMADkAVwA5AFcAawBwAFYASwBrACsANAAwAEcASAAzAFkAVQBKAFIAVgBRAD0APQA8AC8ASwBJAEQAPgA8AEMASABFAEMASwBTAFUATQA+AEkASwB6AFkAMgBIAFoATABBAGwASQA9ADwALwBDAEgARQBDAEsAUwBVAE0APgA8AC8ARABBAFQAQQA+ADwALwBXAFIATQBIAEUAQQBEAEUAUgA+AA==</cenc:pssh>
       </ContentProtection>
       <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"></Role>
+      <SegmentTemplate duration="1968" initialization="$RepresentationID$/audio/en/init.mp4" media="$RepresentationID$/audio/en/seg-$Number$.m4f" startNumber="0" timescale="1000"></SegmentTemplate>
       <Representation audioSamplingRate="44100" bandwidth="67095" codecs="mp4a.40.2" id="800">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
       </Representation>
@@ -25,6 +26,7 @@
         <cenc:pssh>AAACJnBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAgYGAgAAAQABAPwBPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgBMADkAVwA5AFcAawBwAFYASwBrACsANAAwAEcASAAzAFkAVQBKAFIAVgBRAD0APQA8AC8ASwBJAEQAPgA8AEMASABFAEMASwBTAFUATQA+AEkASwB6AFkAMgBIAFoATABBAGwASQA9ADwALwBDAEgARQBDAEsAUwBVAE0APgA8AC8ARABBAFQAQQA+ADwALwBXAFIATQBIAEUAQQBEAEUAUgA+AA==</cenc:pssh>
       </ContentProtection>
       <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"></Role>
+      <SegmentTemplate duration="1968" initialization="$RepresentationID$/video/1/init.mp4" media="$RepresentationID$/video/1/seg-$Number$.m4f" startNumber="0" timescale="1000"></SegmentTemplate>
       <Representation bandwidth="1518664" codecs="avc1.4d401f" frameRate="30000/1001" height="540" id="800" width="960"></Representation>
       <Representation bandwidth="1911775" codecs="avc1.4d401f" frameRate="30000/1001" height="576" id="1000" width="1024"></Representation>
       <Representation bandwidth="2295158" codecs="avc1.4d401f" frameRate="30000/1001" height="576" id="1200" width="1024"></Representation>

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -158,15 +158,15 @@ type SegmentTemplate struct {
 type Representation struct {
 	AdaptationSet             *AdaptationSet             `xml:"-"`
 	AudioChannelConfiguration *AudioChannelConfiguration `xml:"AudioChannelConfiguration,omitempty"`
-	AudioSamplingRate         *int64                     `xml:"audioSamplingRate,attr"` // Audio
-	Bandwidth                 *int64                     `xml:"bandwidth,attr"`         // Audio + Video
-	Codecs                    *string                    `xml:"codecs,attr"`            // Audio + Video
-	FrameRate                 *string                    `xml:"frameRate,attr"`         // Video
-	Height                    *int64                     `xml:"height,attr"`            // Video
-	ID                        *string                    `xml:"id,attr"`                // Audio + Video
-	Width                     *int64                     `xml:"width,attr"`             // Video
-	BaseURL                   *string                    `xml:"BaseURL,omitempty"`      // On-Demand Profile
-	SegmentBase               *SegmentBase               `xml:"SegmentBase,omitempty"`  // On-Demand Profile
+	AudioSamplingRate         *int64                     `xml:"audioSamplingRate,attr"`   // Audio
+	Bandwidth                 *int64                     `xml:"bandwidth,attr"`           // Audio + Video
+	Codecs                    *string                    `xml:"codecs,attr"`              // Audio + Video
+	FrameRate                 *string                    `xml:"frameRate,attr,omitempty"` // Video
+	Height                    *int64                     `xml:"height,attr"`              // Video
+	ID                        *string                    `xml:"id,attr"`                  // Audio + Video
+	Width                     *int64                     `xml:"width,attr"`               // Video
+	BaseURL                   *string                    `xml:"BaseURL,omitempty"`        // On-Demand Profile
+	SegmentBase               *SegmentBase               `xml:"SegmentBase,omitempty"`    // On-Demand Profile
 	SegmentList               *SegmentList               `xml:"SegmentList,omitempty"`
 	SegmentTemplate           *SegmentTemplate           `xml:"SegmentTemplate,omitempty"`
 }
@@ -517,15 +517,6 @@ func (as *AdaptationSet) SetNewSegmentTemplate(duration int64, init string, medi
 
 // Internal helper method for setting the Segment Template on an AdaptationSet.
 func (as *AdaptationSet) setSegmentTemplate(st *SegmentTemplate) error {
-	/*
-		XXX move error checks to a helper on the mpd instance
-			if as.MPD == nil || as.MPD.Profiles == nil {
-				return ErrNoDASHProfileSet
-			}
-			if *as.MPD.Profiles != string(DASH_PROFILE_LIVE) {
-				return ErrSegmentTemplateLiveProfileOnly
-			}
-	*/
 	if st == nil {
 		return ErrSegmentTemplateNil
 	}
@@ -620,12 +611,6 @@ func (as *AdaptationSet) AddNewRole(schemeIDURI string, value string) (*Role, er
 // Sets the BaseURL for a Representation.
 // baseURL - Base URL as a string (i.e. 800k/output-audio-und.mp4)
 func (r *Representation) SetNewBaseURL(baseURL string) error {
-	/*
-		XXX move error check someplace else
-		if r.AdaptationSet == nil || r.AdaptationSet.MPD == nil || r.AdaptationSet.MPD.Profiles == nil {
-			return ErrNoDASHProfileSet
-		}
-	*/
 	if baseURL == "" {
 		return ErrBaseURLEmpty
 	}
@@ -652,15 +637,9 @@ func (r *Representation) AddNewSegmentBase(indexRange string, initRange string) 
 
 // Internal helper method for setting the SegmentBase on a Representation.
 func (r *Representation) setSegmentBase(sb *SegmentBase) error {
-	if r.AdaptationSet == nil /*|| r.AdaptationSet.MPD == nil || r.AdaptationSet.MPD.Profiles == nil*/ {
+	if r.AdaptationSet == nil {
 		return ErrNoDASHProfileSet
 	}
-	/*
-		XXX move checks someplace else
-			if *r.AdaptationSet.MPD.Profiles != (string)(DASH_PROFILE_ONDEMAND) {
-				return ErrSegmentBaseOnDemandProfileOnly
-			}
-	*/
 	if sb == nil {
 		return ErrSegmentBaseNil
 	}
@@ -688,11 +667,6 @@ func (r *Representation) AddNewAudioChannelConfiguration(scheme AudioChannelConf
 
 // Internal helper method for setting the SegmentBase on a Representation.
 func (r *Representation) setAudioChannelConfiguration(acc *AudioChannelConfiguration) error {
-	/* XXX move checks elsewhere
-	if r.AdaptationSet == nil || r.AdaptationSet.MPD == nil || r.AdaptationSet.MPD.Profiles == nil {
-		return ErrNoDASHProfileSet
-	}
-	*/
 	if acc == nil {
 		return ErrAudioChannelConfigurationNil
 	}

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -6,6 +6,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"strings"
+	"time"
 
 	. "github.com/zencoder/go-dash/helpers/ptrs"
 )
@@ -70,7 +71,7 @@ type MPD struct {
 }
 
 type Period struct {
-	//Duration        string           `xml:"duration,attr"`
+	Duration        Duration         `xml:"duration,attr,omitempty"`
 	BaseURL         string           `xml:"BaseURL,omitempty"`
 	SegmentBase     *SegmentBase     `xml:"SegmentBase,omitempty"`
 	SegmentList     *SegmentList     `xml:"SegmentList,omitempty"`
@@ -205,6 +206,10 @@ func (m *MPD) AddNewPeriod() *Period {
 // GetCurrentPeriod returns the current Period.
 func (m *MPD) GetCurrentPeriod() *Period {
 	return m.Period
+}
+
+func (period *Period) SetDuration(d time.Duration) {
+	period.Duration = Duration(d)
 }
 
 // Create a new Adaptation Set for Audio Assets.

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -65,7 +65,8 @@ type MPD struct {
 	MediaPresentationDuration *string `xml:"mediaPresentationDuration,attr"`
 	MinBufferTime             *string `xml:"minBufferTime,attr"`
 	BaseURL                   string  `xml:"BaseURL,omitempty"`
-	Period                    *Period `xml:"Period,omitempty"`
+	Period                    *Period
+	periods                   []*Period `xml:"Period,omitempty"`
 }
 
 type Period struct {
@@ -180,13 +181,15 @@ type AudioChannelConfiguration struct {
 // mediaPresentationDuration - Media Presentation Duration (i.e. PT6M16S).
 // minBufferTime - Min Buffer Time (i.e. PT1.97S).
 func NewMPD(profile DashProfile, mediaPresentationDuration string, minBufferTime string) *MPD {
+	period := &Period{}
 	return &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
 		Profiles: Strptr((string)(profile)),
 		Type:     Strptr("static"),
 		MediaPresentationDuration: Strptr(mediaPresentationDuration),
 		MinBufferTime:             Strptr(minBufferTime),
-		Period:                    &Period{},
+		Period:                    period,
+		periods:                   []*Period{period},
 	}
 }
 
@@ -244,7 +247,7 @@ func (m *MPD) AddNewAdaptationSetSubtitle(mimeType string, lang string) (*Adapta
 	return as, nil
 }
 
-// Internal helper method for adding a AdapatationSet to an MPD.
+// Internal helper method for adding a AdapatationSet to current Period.
 func (m *MPD) addAdaptationSet(as *AdaptationSet) error {
 	if as == nil {
 		return ErrAdaptationSetNil

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -66,8 +66,8 @@ type MPD struct {
 	MediaPresentationDuration *string `xml:"mediaPresentationDuration,attr"`
 	MinBufferTime             *string `xml:"minBufferTime,attr"`
 	BaseURL                   string  `xml:"BaseURL,omitempty"`
-	Period                    *Period
-	periods                   []*Period `xml:"Period,omitempty"`
+	period                    *Period
+	Periods                   []*Period `xml:"Period,omitempty"`
 }
 
 type Period struct {
@@ -80,7 +80,6 @@ type Period struct {
 }
 
 type AdaptationSet struct {
-	//MPD               *MPD                  `xml:"-"`
 	MimeType          *string               `xml:"mimeType,attr"`
 	ScanType          *string               `xml:"scanType,attr"`
 	SegmentAlignment  *bool                 `xml:"segmentAlignment,attr"`
@@ -190,22 +189,22 @@ func NewMPD(profile DashProfile, mediaPresentationDuration string, minBufferTime
 		Type:     Strptr("static"),
 		MediaPresentationDuration: Strptr(mediaPresentationDuration),
 		MinBufferTime:             Strptr(minBufferTime),
-		Period:                    period,
-		periods:                   []*Period{period},
+		period:                    period,
+		Periods:                   []*Period{period},
 	}
 }
 
 // AddNewPeriod creates a new Period and make it the currently active one.
 func (m *MPD) AddNewPeriod() *Period {
 	period := &Period{}
-	m.periods = append(m.periods, period)
-	m.Period = period
+	m.Periods = append(m.Periods, period)
+	m.period = period
 	return period
 }
 
 // GetCurrentPeriod returns the current Period.
 func (m *MPD) GetCurrentPeriod() *Period {
-	return m.Period
+	return m.period
 }
 
 func (period *Period) SetDuration(d time.Duration) {
@@ -218,7 +217,7 @@ func (period *Period) SetDuration(d time.Duration) {
 // startWithSAP - Starts With SAP (i.e. 1).
 // lang - Language (i.e. en).
 func (m *MPD) AddNewAdaptationSetAudio(mimeType string, segmentAlignment bool, startWithSAP int64, lang string) (*AdaptationSet, error) {
-	return m.Period.AddNewAdaptationSetAudio(mimeType, segmentAlignment, startWithSAP, lang)
+	return m.period.AddNewAdaptationSetAudio(mimeType, segmentAlignment, startWithSAP, lang)
 }
 
 // Create a new Adaptation Set for Audio Assets.
@@ -246,7 +245,7 @@ func (period *Period) AddNewAdaptationSetAudio(mimeType string, segmentAlignment
 // segmentAlignment - Segment Alignment(i.e. true).
 // startWithSAP - Starts With SAP (i.e. 1).
 func (m *MPD) AddNewAdaptationSetVideo(mimeType string, scanType string, segmentAlignment bool, startWithSAP int64) (*AdaptationSet, error) {
-	return m.Period.AddNewAdaptationSetVideo(mimeType, scanType, segmentAlignment, startWithSAP)
+	return m.period.AddNewAdaptationSetVideo(mimeType, scanType, segmentAlignment, startWithSAP)
 }
 
 // Create a new Adaptation Set for Video Assets.
@@ -272,7 +271,7 @@ func (period *Period) AddNewAdaptationSetVideo(mimeType string, scanType string,
 // mimeType - MIME Type (i.e. text/vtt).
 // lang - Language (i.e. en).
 func (m *MPD) AddNewAdaptationSetSubtitle(mimeType string, lang string) (*AdaptationSet, error) {
-	return m.Period.AddNewAdaptationSetSubtitle(mimeType, lang)
+	return m.period.AddNewAdaptationSetSubtitle(mimeType, lang)
 }
 
 // Create a new Adaptation Set for Subtitle Assets.
@@ -289,18 +288,6 @@ func (period *Period) AddNewAdaptationSetSubtitle(mimeType string, lang string) 
 	}
 	return as, nil
 }
-
-/*
-// Internal helper method for adding a AdapatationSet to current Period.
-func (m *MPD) addAdaptationSet(as *AdaptationSet) error {
-	if as == nil {
-		return ErrAdaptationSetNil
-	}
-	as.MPD = m   // XXX
-	m.Period.AdaptationSets = append(m.Period.AdaptationSets, as)
-	return nil
-}
-*/
 
 // Internal helper method for adding a AdapatationSet.
 func (period *Period) addAdaptationSet(as *AdaptationSet) error {

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -197,8 +197,8 @@ func NewMPD(profile DashProfile, mediaPresentationDuration string, minBufferTime
 // AddNewPeriod creates a new Period and make it the currently active one.
 func (m *MPD) AddNewPeriod() *Period {
 	period := &Period{}
-	m.Period = period
 	m.periods = append(m.periods, period)
+	m.Period = period
 	return period
 }
 

--- a/mpd/mpd_read_write.go
+++ b/mpd/mpd_read_write.go
@@ -75,15 +75,13 @@ func (m *MPD) WriteToString() (string, error) {
 // Writes an MPD object to an io.Writer interface
 // w - Must implement the io.Writer interface.
 func (m *MPD) Write(w io.Writer) error {
-	// Write out the XML Header
-	w.Write([]byte(xml.Header))
-	// Write out the DASH XML manifest
-	e := xml.NewEncoder(w)
-	e.Indent("", "  ")
-	err := e.Encode(m)
+	b, err := xml.MarshalIndent(m, "", "  ")
 	if err != nil {
 		return err
 	}
+
+	w.Write([]byte(xml.Header))
+	w.Write(b)
 	w.Write([]byte("\n"))
 	return nil
 }

--- a/mpd/mpd_read_write_test.go
+++ b/mpd/mpd_read_write_test.go
@@ -146,20 +146,21 @@ func ExampleAddNewPeriod() {
 	// a new MPD is created with a single Period
 	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
 
-	as, _ := m.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
+	// you can add content to the Period
+	p := m.GetCurrentPeriod()
+	as, _ := p.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 	as.SetNewSegmentTemplate(1968, "$RepresentationID$/video-1.mp4", "$RepresentationID$/video-1/seg-$Number$.m4f", 0, 1000)
 
+	// or directly to the MPD, which will use the current Period.
 	as, _ = m.AddNewAdaptationSetAudio(DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
 	as.SetNewSegmentTemplate(1968, "$RepresentationID$/audio-1.mp4", "$RepresentationID$/audio-1/seg-$Number$.m4f", 0, 1000)
 
 	// add a second period
-	p := m.AddNewPeriod()
+	p = m.AddNewPeriod()
 	p.SetDuration(3 * time.Minute)
-	// you can add content to the Period
 	as, _ = p.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 	as.SetNewSegmentTemplate(1968, "$RepresentationID$/video-2.mp4", "$RepresentationID$/video-2/seg-$Number$.m4f", 0, 1000)
 
-	// or directly to the MPD, which will use the current Period.
 	as, _ = m.AddNewAdaptationSetAudio(DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
 	as.SetNewSegmentTemplate(1968, "$RepresentationID$/audio-2.mp4", "$RepresentationID$/audio-2/seg-$Number$.m4f", 0, 1000)
 

--- a/mpd/mpd_read_write_test.go
+++ b/mpd/mpd_read_write_test.go
@@ -3,10 +3,8 @@ package mpd
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
-	"github.com/martinlindhe/go-difflib/difflib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"github.com/zencoder/go-dash/helpers/testfixtures"
@@ -143,7 +141,6 @@ func (s *MPDReadWriteSuite) TestAddNewAdaptationSetSubtitleWriteToString() {
 	assert.Equal(s.T(), expectedXML, xmlStr)
 }
 
-/*
 func ExampleAddNewPeriod() {
 	// a new MPD is created with a single Period
 	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
@@ -172,12 +169,17 @@ func ExampleAddNewPeriod() {
 	// Output:
 	// <?xml version="1.0" encoding="UTF-8"?>
 	// <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
-	//  <Period>
-	//    <AdaptationSet mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" lang="en"></AdaptationSet>
-	//  </Period>
-	//</MPD>
+	//   <Period>
+	//     <AdaptationSet mimeType="video/mp4" scanType="progressive" segmentAlignment="true" startWithSAP="1">
+	//       <SegmentTemplate duration="1968" initialization="$RepresentationID$/video-2.mp4" media="$RepresentationID$/video-2/seg-$Number$.m4f" startNumber="0" timescale="1000"></SegmentTemplate>
+	//     </AdaptationSet>
+	//     <AdaptationSet mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" lang="en">
+	//       <SegmentTemplate duration="1968" initialization="$RepresentationID$/audio-2.mp4" media="$RepresentationID$/audio-2/seg-$Number$.m4f" startNumber="0" timescale="1000"></SegmentTemplate>
+	//     </AdaptationSet>
+	//   </Period>
+	// </MPD>
 }
-*/
+
 func LiveProfile() *MPD {
 	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
 
@@ -272,36 +274,7 @@ func (s *MPDReadWriteSuite) TestFullHbbTVProfileWriteToString() {
 	xmlStr, err := m.WriteToString()
 	assert.Nil(s.T(), err)
 	expectedXML := testfixtures.LoadFixture("fixtures/hbbtv_profile.mpd")
-	assertCompareRender(s.T(), strings.Split(expectedXML, "\n"), strings.Split(xmlStr, "\n"))
-	// XXX diff
-}
-
-// asserts that expected == got, or fails test
-func assertCompareRender(t *testing.T, expected, got []string) {
-	fail := false
-	if len(expected) != len(got) {
-		t.Error("expected", len(expected), "lines, got", len(got))
-		fail = true
-	}
-	for i, ex := range expected {
-		if i >= len(got) || ex != got[i] {
-			fail = true
-			break
-		}
-	}
-	if fail {
-		diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
-			A:        expected,
-			B:        got,
-			FromFile: "expected",
-			ToFile:   "got",
-			Context:  3,
-			Eol:      "\n",
-		})
-		fmt.Print(diff)
-
-		t.FailNow()
-	}
+	assert.Equal(s.T(), expectedXML, xmlStr)
 }
 
 func (s *MPDReadWriteSuite) TestFullHbbTVProfileWriteToFile() {

--- a/mpd/mpd_read_write_test.go
+++ b/mpd/mpd_read_write_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -148,7 +149,7 @@ func ExampleAddNewPeriod() {
 	// you can add content to the Period
 	p := m.GetCurrentPeriod()
 	// XXX set period duration:
-	// p.SetDuration(2*time.Minute)
+	p.SetDuration(2 * time.Minute)
 	as, _ := p.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 	as.SetNewSegmentTemplate(1968, "$RepresentationID$/video-1.mp4", "$RepresentationID$/video-1/seg-$Number$.m4f", 0, 1000)
 
@@ -158,6 +159,7 @@ func ExampleAddNewPeriod() {
 
 	// add a second period
 	p = m.AddNewPeriod()
+	p.SetDuration(3 * time.Minute)
 	as, _ = p.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 	as.SetNewSegmentTemplate(1968, "$RepresentationID$/video-2.mp4", "$RepresentationID$/video-2/seg-$Number$.m4f", 0, 1000)
 
@@ -169,7 +171,7 @@ func ExampleAddNewPeriod() {
 	// Output:
 	// <?xml version="1.0" encoding="UTF-8"?>
 	// <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
-	//   <Period>
+	//   <Period duration="PT3M0S">
 	//     <AdaptationSet mimeType="video/mp4" scanType="progressive" segmentAlignment="true" startWithSAP="1">
 	//       <SegmentTemplate duration="1968" initialization="$RepresentationID$/video-2.mp4" media="$RepresentationID$/video-2/seg-$Number$.m4f" startNumber="0" timescale="1000"></SegmentTemplate>
 	//     </AdaptationSet>

--- a/mpd/mpd_read_write_test.go
+++ b/mpd/mpd_read_write_test.go
@@ -68,7 +68,11 @@ func (s *MPDReadWriteSuite) TestNewMPDLiveWriteToString() {
 
 	xmlStr, err := m.WriteToString()
 	assert.Nil(s.T(), err)
-	expectedXML := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<MPD xmlns=\"urn:mpeg:dash:schema:mpd:2011\" profiles=\"urn:mpeg:dash:profile:isoff-live:2011\" type=\"static\" mediaPresentationDuration=\"PT6M16S\" minBufferTime=\"PT1.97S\">\n  <Period></Period>\n</MPD>\n"
+	expectedXML := `<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
+  <Period></Period>
+</MPD>
+`
 	assert.Equal(s.T(), expectedXML, xmlStr)
 }
 
@@ -77,7 +81,11 @@ func (s *MPDReadWriteSuite) TestNewMPDOnDemandWriteToString() {
 
 	xmlStr, err := m.WriteToString()
 	assert.Nil(s.T(), err)
-	expectedXML := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<MPD xmlns=\"urn:mpeg:dash:schema:mpd:2011\" profiles=\"urn:mpeg:dash:profile:isoff-on-demand:2011\" type=\"static\" mediaPresentationDuration=\"PT6M16S\" minBufferTime=\"PT1.97S\">\n  <Period></Period>\n</MPD>\n"
+	expectedXML := `<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
+  <Period></Period>
+</MPD>
+`
 	assert.Equal(s.T(), expectedXML, xmlStr)
 }
 
@@ -88,7 +96,13 @@ func (s *MPDReadWriteSuite) TestAddNewAdaptationSetAudioWriteToString() {
 
 	xmlStr, err := m.WriteToString()
 	assert.Nil(s.T(), err)
-	expectedXML := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<MPD xmlns=\"urn:mpeg:dash:schema:mpd:2011\" profiles=\"urn:mpeg:dash:profile:isoff-live:2011\" type=\"static\" mediaPresentationDuration=\"PT6M16S\" minBufferTime=\"PT1.97S\">\n  <Period>\n    <AdaptationSet mimeType=\"audio/mp4\" segmentAlignment=\"true\" startWithSAP=\"1\" lang=\"en\"></AdaptationSet>\n  </Period>\n</MPD>\n"
+	expectedXML := `<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
+  <Period>
+    <AdaptationSet mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" lang="en"></AdaptationSet>
+  </Period>
+</MPD>
+`
 	assert.Equal(s.T(), expectedXML, xmlStr)
 }
 
@@ -99,7 +113,13 @@ func (s *MPDReadWriteSuite) TestAddNewAdaptationSetVideoWriteToString() {
 
 	xmlStr, err := m.WriteToString()
 	assert.Nil(s.T(), err)
-	expectedXML := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<MPD xmlns=\"urn:mpeg:dash:schema:mpd:2011\" profiles=\"urn:mpeg:dash:profile:isoff-live:2011\" type=\"static\" mediaPresentationDuration=\"PT6M16S\" minBufferTime=\"PT1.97S\">\n  <Period>\n    <AdaptationSet mimeType=\"video/mp4\" scanType=\"progressive\" segmentAlignment=\"true\" startWithSAP=\"1\"></AdaptationSet>\n  </Period>\n</MPD>\n"
+	expectedXML := `<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
+  <Period>
+    <AdaptationSet mimeType="video/mp4" scanType="progressive" segmentAlignment="true" startWithSAP="1"></AdaptationSet>
+  </Period>
+</MPD>
+`
 	assert.Equal(s.T(), expectedXML, xmlStr)
 }
 
@@ -110,7 +130,13 @@ func (s *MPDReadWriteSuite) TestAddNewAdaptationSetSubtitleWriteToString() {
 
 	xmlStr, err := m.WriteToString()
 	assert.Nil(s.T(), err)
-	expectedXML := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<MPD xmlns=\"urn:mpeg:dash:schema:mpd:2011\" profiles=\"urn:mpeg:dash:profile:isoff-live:2011\" type=\"static\" mediaPresentationDuration=\"PT6M16S\" minBufferTime=\"PT1.97S\">\n  <Period>\n    <AdaptationSet mimeType=\"text/vtt\" lang=\"en\"></AdaptationSet>\n  </Period>\n</MPD>\n"
+	expectedXML := `<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
+  <Period>
+    <AdaptationSet mimeType="text/vtt" lang="en"></AdaptationSet>
+  </Period>
+</MPD>
+`
 	assert.Equal(s.T(), expectedXML, xmlStr)
 }
 

--- a/mpd/mpd_read_write_test.go
+++ b/mpd/mpd_read_write_test.go
@@ -146,23 +146,20 @@ func ExampleAddNewPeriod() {
 	// a new MPD is created with a single Period
 	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
 
-	// you can add content to the Period
-	p := m.GetCurrentPeriod()
-	// XXX set period duration:
-	p.SetDuration(2 * time.Minute)
-	as, _ := p.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
+	as, _ := m.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 	as.SetNewSegmentTemplate(1968, "$RepresentationID$/video-1.mp4", "$RepresentationID$/video-1/seg-$Number$.m4f", 0, 1000)
 
-	// or directly to the MPD, which will use the current Period.
 	as, _ = m.AddNewAdaptationSetAudio(DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
 	as.SetNewSegmentTemplate(1968, "$RepresentationID$/audio-1.mp4", "$RepresentationID$/audio-1/seg-$Number$.m4f", 0, 1000)
 
 	// add a second period
-	p = m.AddNewPeriod()
+	p := m.AddNewPeriod()
 	p.SetDuration(3 * time.Minute)
+	// you can add content to the Period
 	as, _ = p.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 	as.SetNewSegmentTemplate(1968, "$RepresentationID$/video-2.mp4", "$RepresentationID$/video-2/seg-$Number$.m4f", 0, 1000)
 
+	// or directly to the MPD, which will use the current Period.
 	as, _ = m.AddNewAdaptationSetAudio(DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
 	as.SetNewSegmentTemplate(1968, "$RepresentationID$/audio-2.mp4", "$RepresentationID$/audio-2/seg-$Number$.m4f", 0, 1000)
 
@@ -171,6 +168,14 @@ func ExampleAddNewPeriod() {
 	// Output:
 	// <?xml version="1.0" encoding="UTF-8"?>
 	// <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
+	//   <Period>
+	//     <AdaptationSet mimeType="video/mp4" scanType="progressive" segmentAlignment="true" startWithSAP="1">
+	//       <SegmentTemplate duration="1968" initialization="$RepresentationID$/video-1.mp4" media="$RepresentationID$/video-1/seg-$Number$.m4f" startNumber="0" timescale="1000"></SegmentTemplate>
+	//     </AdaptationSet>
+	//     <AdaptationSet mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" lang="en">
+	//       <SegmentTemplate duration="1968" initialization="$RepresentationID$/audio-1.mp4" media="$RepresentationID$/audio-1/seg-$Number$.m4f" startNumber="0" timescale="1000"></SegmentTemplate>
+	//     </AdaptationSet>
+	//   </Period>
 	//   <Period duration="PT3M0S">
 	//     <AdaptationSet mimeType="video/mp4" scanType="progressive" segmentAlignment="true" startWithSAP="1">
 	//       <SegmentTemplate duration="1968" initialization="$RepresentationID$/video-2.mp4" media="$RepresentationID$/video-2/seg-$Number$.m4f" startNumber="0" timescale="1000"></SegmentTemplate>

--- a/mpd/mpd_read_write_test.go
+++ b/mpd/mpd_read_write_test.go
@@ -1,9 +1,12 @@
 package mpd
 
 import (
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/martinlindhe/go-difflib/difflib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"github.com/zencoder/go-dash/helpers/testfixtures"
@@ -140,6 +143,41 @@ func (s *MPDReadWriteSuite) TestAddNewAdaptationSetSubtitleWriteToString() {
 	assert.Equal(s.T(), expectedXML, xmlStr)
 }
 
+/*
+func ExampleAddNewPeriod() {
+	// a new MPD is created with a single Period
+	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+
+	// you can add content to the Period
+	p := m.GetCurrentPeriod()
+	// XXX set period duration:
+	// p.SetDuration(2*time.Minute)
+	as, _ := p.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
+	as.SetNewSegmentTemplate(1968, "$RepresentationID$/video-1.mp4", "$RepresentationID$/video-1/seg-$Number$.m4f", 0, 1000)
+
+	// or directly to the MPD, which will use the current Period.
+	as, _ = m.AddNewAdaptationSetAudio(DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
+	as.SetNewSegmentTemplate(1968, "$RepresentationID$/audio-1.mp4", "$RepresentationID$/audio-1/seg-$Number$.m4f", 0, 1000)
+
+	// add a second period
+	p = m.AddNewPeriod()
+	as, _ = p.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
+	as.SetNewSegmentTemplate(1968, "$RepresentationID$/video-2.mp4", "$RepresentationID$/video-2/seg-$Number$.m4f", 0, 1000)
+
+	as, _ = m.AddNewAdaptationSetAudio(DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
+	as.SetNewSegmentTemplate(1968, "$RepresentationID$/audio-2.mp4", "$RepresentationID$/audio-2/seg-$Number$.m4f", 0, 1000)
+
+	xmlStr, _ := m.WriteToString()
+	fmt.Print(xmlStr)
+	// Output:
+	// <?xml version="1.0" encoding="UTF-8"?>
+	// <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
+	//  <Period>
+	//    <AdaptationSet mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" lang="en"></AdaptationSet>
+	//  </Period>
+	//</MPD>
+}
+*/
 func LiveProfile() *MPD {
 	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
 
@@ -234,7 +272,36 @@ func (s *MPDReadWriteSuite) TestFullHbbTVProfileWriteToString() {
 	xmlStr, err := m.WriteToString()
 	assert.Nil(s.T(), err)
 	expectedXML := testfixtures.LoadFixture("fixtures/hbbtv_profile.mpd")
-	assert.Equal(s.T(), expectedXML, xmlStr)
+	assertCompareRender(s.T(), strings.Split(expectedXML, "\n"), strings.Split(xmlStr, "\n"))
+	// XXX diff
+}
+
+// asserts that expected == got, or fails test
+func assertCompareRender(t *testing.T, expected, got []string) {
+	fail := false
+	if len(expected) != len(got) {
+		t.Error("expected", len(expected), "lines, got", len(got))
+		fail = true
+	}
+	for i, ex := range expected {
+		if i >= len(got) || ex != got[i] {
+			fail = true
+			break
+		}
+	}
+	if fail {
+		diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+			A:        expected,
+			B:        got,
+			FromFile: "expected",
+			ToFile:   "got",
+			Context:  3,
+			Eol:      "\n",
+		})
+		fmt.Print(diff)
+
+		t.FailNow()
+	}
 }
 
 func (s *MPDReadWriteSuite) TestFullHbbTVProfileWriteToFile() {

--- a/mpd/mpd_test.go
+++ b/mpd/mpd_test.go
@@ -176,7 +176,6 @@ func (s *MPDSuite) TestAddNewAdaptationSetAudio() {
 	assert.NotNil(s.T(), as)
 	assert.Nil(s.T(), err)
 	expectedAS := &AdaptationSet{
-		MPD:              m,
 		MimeType:         Strptr(VALID_MIME_TYPE_AUDIO),
 		SegmentAlignment: Boolptr(VALID_SEGMENT_ALIGNMENT),
 		StartWithSAP:     Int64ptr(VALID_START_WITH_SAP),
@@ -192,7 +191,6 @@ func (s *MPDSuite) TestAddNewAdaptationSetVideo() {
 	assert.NotNil(s.T(), as)
 	assert.Nil(s.T(), err)
 	expectedAS := &AdaptationSet{
-		MPD:              m,
 		MimeType:         Strptr(VALID_MIME_TYPE_VIDEO),
 		ScanType:         Strptr(VALID_SCAN_TYPE),
 		SegmentAlignment: Boolptr(VALID_SEGMENT_ALIGNMENT),
@@ -208,7 +206,6 @@ func (s *MPDSuite) TestAddNewAdaptationSetSubtitle() {
 	assert.NotNil(s.T(), as)
 	assert.Nil(s.T(), err)
 	expectedAS := &AdaptationSet{
-		MPD:      m,
 		MimeType: Strptr(VALID_MIME_TYPE_SUBTITLE_VTT),
 		Lang:     Strptr(VALID_LANG),
 	}
@@ -218,7 +215,7 @@ func (s *MPDSuite) TestAddNewAdaptationSetSubtitle() {
 func (s *MPDSuite) TestAddAdaptationSetErrorNil() {
 	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
 
-	err := m.addAdaptationSet(nil)
+	err := m.Period.addAdaptationSet(nil)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), ErrAdaptationSetNil, err)
 }
@@ -406,6 +403,7 @@ func (s *MPDSuite) TestSetNewSegmentTemplate() {
 	assert.Nil(s.T(), err)
 }
 
+/*
 func (s *MPDSuite) TestSetNewSegmentTemplateErrorInvalidProfile() {
 	m := NewMPD(DASH_PROFILE_ONDEMAND, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
 	audioAS, _ := m.AddNewAdaptationSetAudio(DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
@@ -414,7 +412,9 @@ func (s *MPDSuite) TestSetNewSegmentTemplateErrorInvalidProfile() {
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), ErrSegmentTemplateLiveProfileOnly, err)
 }
+*/
 
+/*
 func (s *MPDSuite) TestSetNewSegmentTemplateErrorNoDASHProfile() {
 	m := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
@@ -430,6 +430,7 @@ func (s *MPDSuite) TestSetNewSegmentTemplateErrorNoDASHProfile() {
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), ErrNoDASHProfileSet, err)
 }
+*/
 
 func (s *MPDSuite) TestAddRepresentationAudio() {
 	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
@@ -523,6 +524,7 @@ func (s *MPDSuite) TestSetNewBaseURLSubtitle() {
 	assert.Nil(s.T(), err)
 }
 
+/*
 func (s *MPDSuite) TestSetNewBaseURLErrorNoDASHProfile() {
 	m := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
@@ -541,6 +543,7 @@ func (s *MPDSuite) TestSetNewBaseURLErrorNoDASHProfile() {
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), ErrNoDASHProfileSet, err)
 }
+*/
 
 func (s *MPDSuite) TestSetNewBaseURLErrorEmpty() {
 	m := NewMPD(DASH_PROFILE_ONDEMAND, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
@@ -565,6 +568,7 @@ func (s *MPDSuite) TestSetNewSegmentBase() {
 	assert.Nil(s.T(), err)
 }
 
+/*
 func (s *MPDSuite) TestSetNewSegmentBaseErrorInvalidDASHProfile() {
 	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
 	videoAS, _ := m.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
@@ -576,7 +580,9 @@ func (s *MPDSuite) TestSetNewSegmentBaseErrorInvalidDASHProfile() {
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), ErrSegmentBaseOnDemandProfileOnly, err)
 }
+*/
 
+/*
 func (s *MPDSuite) TestSetNewSegmentBaseErrorNoDASHProfile() {
 	m := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
@@ -595,6 +601,7 @@ func (s *MPDSuite) TestSetNewSegmentBaseErrorNoDASHProfile() {
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), ErrNoDASHProfileSet, err)
 }
+*/
 
 func (s *MPDSuite) TestSetSegmentBaseErrorNil() {
 	m := NewMPD(DASH_PROFILE_ONDEMAND, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)

--- a/mpd/mpd_test.go
+++ b/mpd/mpd_test.go
@@ -75,6 +75,7 @@ func (s *MPDSuite) TestNewMPDLive() {
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
 		Period:                    &Period{},
+		periods:                   []*Period{&Period{}},
 	}
 	assert.Equal(s.T(), expectedMPD, m)
 }
@@ -114,6 +115,7 @@ func (s *MPDSuite) TestNewMPDLiveWithBaseURLInMPD() {
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
 		Period:                    &Period{},
+		periods:                   []*Period{&Period{}},
 		BaseURL:                   VALID_BASE_URL_VIDEO,
 	}
 	assert.Equal(s.T(), expectedMPD, m)
@@ -123,15 +125,17 @@ func (s *MPDSuite) TestNewMPDLiveWithBaseURLInPeriod() {
 	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
 	m.Period.BaseURL = VALID_BASE_URL_VIDEO
 	assert.NotNil(s.T(), m)
+	period := &Period{
+		BaseURL: VALID_BASE_URL_VIDEO,
+	}
 	expectedMPD := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
 		Profiles: Strptr((string)(DASH_PROFILE_LIVE)),
 		Type:     Strptr("static"),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
-		Period: &Period{
-			BaseURL: VALID_BASE_URL_VIDEO,
-		},
+		Period:                    period,
+		periods:                   []*Period{period},
 	}
 	assert.Equal(s.T(), expectedMPD, m)
 }
@@ -146,6 +150,7 @@ func (s *MPDSuite) TestNewMPDHbbTV() {
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
 		Period:                    &Period{},
+		periods:                   []*Period{&Period{}},
 	}
 	assert.Equal(s.T(), expectedMPD, m)
 }
@@ -160,6 +165,7 @@ func (s *MPDSuite) TestNewMPDOnDemand() {
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
 		Period:                    &Period{},
+		periods:                   []*Period{&Period{}},
 	}
 	assert.Equal(s.T(), expectedMPD, m)
 }

--- a/mpd/mpd_test.go
+++ b/mpd/mpd_test.go
@@ -74,8 +74,8 @@ func (s *MPDSuite) TestNewMPDLive() {
 		Type:     Strptr("static"),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
-		Period:                    &Period{},
-		periods:                   []*Period{&Period{}},
+		period:                    &Period{},
+		Periods:                   []*Period{&Period{}},
 	}
 	assert.Equal(s.T(), expectedMPD, m)
 }
@@ -114,8 +114,8 @@ func (s *MPDSuite) TestNewMPDLiveWithBaseURLInMPD() {
 		Type:     Strptr("static"),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
-		Period:                    &Period{},
-		periods:                   []*Period{&Period{}},
+		period:                    &Period{},
+		Periods:                   []*Period{&Period{}},
 		BaseURL:                   VALID_BASE_URL_VIDEO,
 	}
 	assert.Equal(s.T(), expectedMPD, m)
@@ -123,7 +123,7 @@ func (s *MPDSuite) TestNewMPDLiveWithBaseURLInMPD() {
 
 func (s *MPDSuite) TestNewMPDLiveWithBaseURLInPeriod() {
 	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
-	m.Period.BaseURL = VALID_BASE_URL_VIDEO
+	m.period.BaseURL = VALID_BASE_URL_VIDEO
 	assert.NotNil(s.T(), m)
 	period := &Period{
 		BaseURL: VALID_BASE_URL_VIDEO,
@@ -134,8 +134,8 @@ func (s *MPDSuite) TestNewMPDLiveWithBaseURLInPeriod() {
 		Type:     Strptr("static"),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
-		Period:                    period,
-		periods:                   []*Period{period},
+		period:                    period,
+		Periods:                   []*Period{period},
 	}
 	assert.Equal(s.T(), expectedMPD, m)
 }
@@ -149,8 +149,8 @@ func (s *MPDSuite) TestNewMPDHbbTV() {
 		Type:     Strptr("static"),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
-		Period:                    &Period{},
-		periods:                   []*Period{&Period{}},
+		period:                    &Period{},
+		Periods:                   []*Period{&Period{}},
 	}
 	assert.Equal(s.T(), expectedMPD, m)
 }
@@ -164,8 +164,8 @@ func (s *MPDSuite) TestNewMPDOnDemand() {
 		Type:     Strptr("static"),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
-		Period:                    &Period{},
-		periods:                   []*Period{&Period{}},
+		period:                    &Period{},
+		Periods:                   []*Period{&Period{}},
 	}
 	assert.Equal(s.T(), expectedMPD, m)
 }
@@ -215,7 +215,7 @@ func (s *MPDSuite) TestAddNewAdaptationSetSubtitle() {
 func (s *MPDSuite) TestAddAdaptationSetErrorNil() {
 	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
 
-	err := m.Period.addAdaptationSet(nil)
+	err := m.period.addAdaptationSet(nil)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), ErrAdaptationSetNil, err)
 }

--- a/mpd/mpd_test.go
+++ b/mpd/mpd_test.go
@@ -403,18 +403,6 @@ func (s *MPDSuite) TestSetNewSegmentTemplate() {
 	assert.Nil(s.T(), err)
 }
 
-/*
-func (s *MPDSuite) TestSetNewSegmentTemplateErrorInvalidProfile() {
-	m := NewMPD(DASH_PROFILE_ONDEMAND, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
-	audioAS, _ := m.AddNewAdaptationSetAudio(DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
-	st, err := audioAS.SetNewSegmentTemplate(VALID_DURATION, VALID_INIT_PATH_AUDIO, VALID_MEDIA_PATH_AUDIO, VALID_START_NUMBER, VALID_TIMESCALE)
-	assert.Nil(s.T(), st)
-	assert.NotNil(s.T(), err)
-	assert.Equal(s.T(), ErrSegmentTemplateLiveProfileOnly, err)
-}
-*/
-
-/*
 func (s *MPDSuite) TestSetNewSegmentTemplateErrorNoDASHProfile() {
 	m := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
@@ -422,15 +410,13 @@ func (s *MPDSuite) TestSetNewSegmentTemplateErrorNoDASHProfile() {
 		Type:     Strptr("static"),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
-		Period:                    &Period{},
+		period:                    &Period{},
 	}
 	audioAS, _ := m.AddNewAdaptationSetAudio(DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
-	st, err := audioAS.SetNewSegmentTemplate(VALID_DURATION, VALID_INIT_PATH_AUDIO, VALID_MEDIA_PATH_AUDIO, VALID_START_NUMBER, VALID_TIMESCALE)
-	assert.Nil(s.T(), st)
-	assert.NotNil(s.T(), err)
+	audioAS.SetNewSegmentTemplate(VALID_DURATION, VALID_INIT_PATH_AUDIO, VALID_MEDIA_PATH_AUDIO, VALID_START_NUMBER, VALID_TIMESCALE)
+	err := m.Validate()
 	assert.Equal(s.T(), ErrNoDASHProfileSet, err)
 }
-*/
 
 func (s *MPDSuite) TestAddRepresentationAudio() {
 	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
@@ -524,7 +510,6 @@ func (s *MPDSuite) TestSetNewBaseURLSubtitle() {
 	assert.Nil(s.T(), err)
 }
 
-/*
 func (s *MPDSuite) TestSetNewBaseURLErrorNoDASHProfile() {
 	m := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
@@ -532,18 +517,18 @@ func (s *MPDSuite) TestSetNewBaseURLErrorNoDASHProfile() {
 		Type:     Strptr("static"),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
-		Period:                    &Period{},
+		period:                    &Period{},
 	}
 	videoAS, _ := m.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	r, _ := videoAS.AddNewRepresentationVideo(VALID_VIDEO_BITRATE, VALID_VIDEO_CODEC, VALID_VIDEO_ID, VALID_VIDEO_FRAMERATE, VALID_VIDEO_WIDTH, VALID_VIDEO_HEIGHT)
 
-	err := r.SetNewBaseURL(VALID_BASE_URL_VIDEO)
+	r.SetNewBaseURL(VALID_BASE_URL_VIDEO)
+	err := m.Validate()
 
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), ErrNoDASHProfileSet, err)
 }
-*/
 
 func (s *MPDSuite) TestSetNewBaseURLErrorEmpty() {
 	m := NewMPD(DASH_PROFILE_ONDEMAND, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
@@ -568,21 +553,6 @@ func (s *MPDSuite) TestSetNewSegmentBase() {
 	assert.Nil(s.T(), err)
 }
 
-/*
-func (s *MPDSuite) TestSetNewSegmentBaseErrorInvalidDASHProfile() {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
-	videoAS, _ := m.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
-
-	r, _ := videoAS.AddNewRepresentationVideo(VALID_VIDEO_BITRATE, VALID_VIDEO_CODEC, VALID_VIDEO_ID, VALID_VIDEO_FRAMERATE, VALID_VIDEO_WIDTH, VALID_VIDEO_HEIGHT)
-
-	sb, err := r.AddNewSegmentBase(VALID_INDEX_RANGE, VALID_INIT_RANGE)
-	assert.Nil(s.T(), sb)
-	assert.NotNil(s.T(), err)
-	assert.Equal(s.T(), ErrSegmentBaseOnDemandProfileOnly, err)
-}
-*/
-
-/*
 func (s *MPDSuite) TestSetNewSegmentBaseErrorNoDASHProfile() {
 	m := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
@@ -590,18 +560,17 @@ func (s *MPDSuite) TestSetNewSegmentBaseErrorNoDASHProfile() {
 		Type:     Strptr("static"),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
-		Period:                    &Period{},
+		period:                    &Period{},
 	}
 	videoAS, _ := m.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	r, _ := videoAS.AddNewRepresentationVideo(VALID_VIDEO_BITRATE, VALID_VIDEO_CODEC, VALID_VIDEO_ID, VALID_VIDEO_FRAMERATE, VALID_VIDEO_WIDTH, VALID_VIDEO_HEIGHT)
 
-	sb, err := r.AddNewSegmentBase(VALID_INDEX_RANGE, VALID_INIT_RANGE)
-	assert.Nil(s.T(), sb)
-	assert.NotNil(s.T(), err)
+	r.AddNewSegmentBase(VALID_INDEX_RANGE, VALID_INIT_RANGE)
+
+	err := m.Validate()
 	assert.Equal(s.T(), ErrNoDASHProfileSet, err)
 }
-*/
 
 func (s *MPDSuite) TestSetSegmentBaseErrorNil() {
 	m := NewMPD(DASH_PROFILE_ONDEMAND, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)

--- a/mpd/segment_list_test.go
+++ b/mpd/segment_list_test.go
@@ -39,10 +39,10 @@ func (s *SegmentListSuite) TestSegmentListDeserialization() {
 	if err == nil {
 		expected := getSegmentListMPD()
 
-		s.Equal(expected.Period.BaseURL, m.Period.BaseURL)
+		s.Equal(expected.Periods[0].BaseURL, m.Periods[0].BaseURL)
 
-		expectedAudioSegList := expected.Period.AdaptationSets[0].Representations[0].SegmentList
-		audioSegList := m.Period.AdaptationSets[0].Representations[0].SegmentList
+		expectedAudioSegList := expected.Periods[0].AdaptationSets[0].Representations[0].SegmentList
+		audioSegList := m.Periods[0].AdaptationSets[0].Representations[0].SegmentList
 
 		s.Equal(expectedAudioSegList.Timescale, audioSegList.Timescale)
 		s.Equal(expectedAudioSegList.Duration, audioSegList.Duration)
@@ -52,8 +52,8 @@ func (s *SegmentListSuite) TestSegmentListDeserialization() {
 			s.Equal(expectedAudioSegList.SegmentURLs[i], audioSegList.SegmentURLs[i])
 		}
 
-		expectedVideoSegList := expected.Period.AdaptationSets[1].Representations[0].SegmentList
-		videoSegList := m.Period.AdaptationSets[1].Representations[0].SegmentList
+		expectedVideoSegList := expected.Periods[0].AdaptationSets[1].Representations[0].SegmentList
+		videoSegList := m.Periods[0].AdaptationSets[1].Representations[0].SegmentList
 
 		s.Equal(expectedVideoSegList.Timescale, videoSegList.Timescale)
 		s.Equal(expectedVideoSegList.Duration, videoSegList.Duration)
@@ -67,7 +67,7 @@ func (s *SegmentListSuite) TestSegmentListDeserialization() {
 
 func getSegmentListMPD() *MPD {
 	m := NewMPD(DASH_PROFILE_LIVE, "PT30.016S", "PT2.000S")
-	m.Period.BaseURL = "http://localhost:8002/dash/"
+	m.period.BaseURL = "http://localhost:8002/dash/"
 
 	aas, _ := m.AddNewAdaptationSetAudio("audio/mp4", true, 1, "English")
 	ra, _ := aas.AddNewRepresentationAudio(48000, 255000, "mp4a.40.2", "audio_1")

--- a/mpd/segment_timeline_test.go
+++ b/mpd/segment_timeline_test.go
@@ -39,17 +39,17 @@ func (s *SegmentListSuite) TestSegmentTimelineDeserialization() {
 	if err == nil {
 		expected := getSegmentTimelineMPD()
 
-		s.Equal(expected.Period.BaseURL, m.Period.BaseURL)
+		s.Equal(expected.Periods[0].BaseURL, m.Periods[0].BaseURL)
 
-		expectedAudioSegTimeline := expected.Period.AdaptationSets[0].Representations[0].SegmentTemplate.SegmentTimeline
-		audioSegTimeline := m.Period.AdaptationSets[0].Representations[0].SegmentTemplate.SegmentTimeline
+		expectedAudioSegTimeline := expected.Periods[0].AdaptationSets[0].Representations[0].SegmentTemplate.SegmentTimeline
+		audioSegTimeline := m.Periods[0].AdaptationSets[0].Representations[0].SegmentTemplate.SegmentTimeline
 
 		for i := range expectedAudioSegTimeline.Segments {
 			s.Equal(expectedAudioSegTimeline.Segments[i], audioSegTimeline.Segments[i])
 		}
 
-		expectedVideoSegTimeline := expected.Period.AdaptationSets[1].Representations[0].SegmentTemplate.SegmentTimeline
-		videoSegTimeline := m.Period.AdaptationSets[1].Representations[0].SegmentTemplate.SegmentTimeline
+		expectedVideoSegTimeline := expected.Periods[0].AdaptationSets[1].Representations[0].SegmentTemplate.SegmentTimeline
+		videoSegTimeline := m.Periods[0].AdaptationSets[1].Representations[0].SegmentTemplate.SegmentTimeline
 
 		for i := range expectedVideoSegTimeline.Segments {
 			s.Equal(expectedVideoSegTimeline.Segments[i], videoSegTimeline.Segments[i])
@@ -59,7 +59,7 @@ func (s *SegmentListSuite) TestSegmentTimelineDeserialization() {
 
 func getSegmentTimelineMPD() *MPD {
 	m := NewMPD(DASH_PROFILE_LIVE, "PT65.063S", "PT2.000S")
-	m.Period.BaseURL = "http://localhost:8002/public/"
+	m.period.BaseURL = "http://localhost:8002/public/"
 
 	aas, _ := m.AddNewAdaptationSetAudio("audio/mp4", true, 1, "English")
 	ra, _ := aas.AddNewRepresentationAudio(48000, 255000, "mp4a.40.2", "audio_1")

--- a/mpd/validate.go
+++ b/mpd/validate.go
@@ -1,0 +1,9 @@
+package mpd
+
+// Validate checks for incomplete MPD object
+func (m *MPD) Validate() error {
+	if m.Profiles == nil {
+		return ErrNoDASHProfileSet
+	}
+	return nil
+}


### PR DESCRIPTION
Hello and thanks for a cool project!

This PR adds support for multiple periods.
It extends upon the existing API, so it should not require any changes to existing client code.

Also included:
* xml marshaller for the xml duration type "PT6M" = 6 minutes
* an ExampleAddNewPeriod to show usage
* removed internal pointers to *MPD, simplified some.
* moved "invalid state" checks to separate `func (m *MPD) Validate()`
* minor cleanup


### example usage for multiple periods
```go
	// a new MPD is created with a single Period
	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)

	as, _ := m.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
	as.SetNewSegmentTemplate(1968, "$RepresentationID$/video-1.mp4", "$RepresentationID$/video-1/seg-$Number$.m4f", 0, 1000)

	as, _ = m.AddNewAdaptationSetAudio(DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
	as.SetNewSegmentTemplate(1968, "$RepresentationID$/audio-1.mp4", "$RepresentationID$/audio-1/seg-$Number$.m4f", 0, 1000)

	// add a second period
	p := m.AddNewPeriod()
	p.SetDuration(3 * time.Minute)
	// you can add content to the Period
	as, _ = p.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
	as.SetNewSegmentTemplate(1968, "$RepresentationID$/video-2.mp4", "$RepresentationID$/video-2/seg-$Number$.m4f", 0, 1000)

	// or directly to the MPD, which will use the current Period.
	as, _ = m.AddNewAdaptationSetAudio(DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
	as.SetNewSegmentTemplate(1968, "$RepresentationID$/audio-2.mp4", "$RepresentationID$/audio-2/seg-$Number$.m4f", 0, 1000)
```