### PR TITLE
Implement to unmarshal PT duration

### DIFF
--- a/mpd/duration_test.go
+++ b/mpd/duration_test.go
@@ -23,21 +23,16 @@ func TestDuration(t *testing.T) {
 
 func TestParseDuration(t *testing.T) {
 	in := map[string]float64{
-		"PT0S":                 0,
-		"PT1M":                 60,
-		"PT2H":                 7200,
-		"PT6M16S":              376,
-		"PT1.97S":              1.97,
-		"PT1H2M3.456S":         3723.456,
-		"P1YT2M3S":             (365*24*time.Hour + 2*time.Minute + 3*time.Second).Seconds(),
-		"P1Y2M3DT12H34M56.78S": (365*24*time.Hour + 59*24*time.Hour + 3*24*time.Hour + 12*time.Hour + 34*time.Minute + 56*time.Second + 780*time.Millisecond).Seconds(),
-		"P1DT2H":               (26 * time.Hour).Seconds(),
-		"P20M":                 (608 * 24 * time.Hour).Seconds(),
-		"PT20M":                (20 * time.Minute).Seconds(),
-		"P0Y20M0D":             (608 * 24 * time.Hour).Seconds(),
-		"P0Y":                  0,
-		"-P60D":                -(60 * 24 * time.Hour).Seconds(),
-		"PT1M30.5S":            (time.Minute + 30*time.Second + 500*time.Millisecond).Seconds(),
+		"PT0S":         0,
+		"PT1M":         60,
+		"PT2H":         7200,
+		"PT6M16S":      376,
+		"PT1.97S":      1.97,
+		"PT1H2M3.456S": 3723.456,
+		"P1DT2H":       (26 * time.Hour).Seconds(),
+		"PT20M":        (20 * time.Minute).Seconds(),
+		"-P60D":        -(60 * 24 * time.Hour).Seconds(),
+		"PT1M30.5S":    (time.Minute + 30*time.Second + 500*time.Millisecond).Seconds(),
 	}
 	for ins, ex := range in {
 		act, err := parseDuration(ins)

--- a/mpd/duration_test.go
+++ b/mpd/duration_test.go
@@ -20,3 +20,28 @@ func TestDuration(t *testing.T) {
 		assert.Equal(t, ex, dur.String())
 	}
 }
+
+func TestParseDuration(t *testing.T) {
+	in := map[string]float64{
+		"PT0S":                 0,
+		"PT1M":                 60,
+		"PT2H":                 7200,
+		"PT6M16S":              376,
+		"PT1.97S":              1.97,
+		"PT1H2M3.456S":         3723.456,
+		"P1YT2M3S":             (365*24*time.Hour + 2*time.Minute + 3*time.Second).Seconds(),
+		"P1Y2M3DT12H34M56.78S": (365*24*time.Hour + 59*24*time.Hour + 3*24*time.Hour + 12*time.Hour + 34*time.Minute + 56*time.Second + 780*time.Millisecond).Seconds(),
+		"P1DT2H":               (26 * time.Hour).Seconds(),
+		"P20M":                 (608 * 24 * time.Hour).Seconds(),
+		"PT20M":                (20 * time.Minute).Seconds(),
+		"P0Y20M0D":             (608 * 24 * time.Hour).Seconds(),
+		"P0Y":                  0,
+		"-P60D":                -(60 * 24 * time.Hour).Seconds(),
+		"PT1M30.5S":            (time.Minute + 30*time.Second + 500*time.Millisecond).Seconds(),
+	}
+	for ins, ex := range in {
+		act, err := parseDuration(ins)
+		assert.NoError(t, err, ins)
+		assert.Equal(t, ex, act.Seconds(), ins)
+	}
+}


### PR DESCRIPTION
Refer to #23

go-dash output the MPD with PT duration, but could not parse its notation.
This PR resolve an above issue.
However, It might be including the mistake due to I can not read the full specification of MPEG-DASH.