### PR TITLE
Add availabilityStartTime attribute support

### DIFF
--- a/helpers/ptrs/ptrs.go
+++ b/helpers/ptrs/ptrs.go
@@ -6,6 +6,13 @@ func Strptr(v string) *string {
 	return p
 }
 
+func EmptyStrPtr(v string) *string {
+	if v == "" {
+		return nil
+	}
+	return Strptr(v)
+}
+
 func Intptr(v int) *int {
 	p := new(int)
 	*p = v

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -28,6 +28,7 @@ const (
 const (
 	ATTR_TYPE                        = "type"
 	ATTR_TYPE_STATIC                 = "static"
+	ATTR_TYPE_DYNAMIC                = "dynamic"
 	ATTR_MEDIA_PRESENTATION_DURATION = "mediaPresentationDuration"
 	ATTR_MIN_BUFFER_TIME             = "minBufferTime"
 	ATTR_AVAILABILITY_START_TIME     = "availabilityStartTime"

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -64,6 +64,7 @@ type MPD struct {
 	Profiles                  *string `xml:"profiles,attr"`
 	Type                      *string `xml:"type,attr"`
 	MediaPresentationDuration *string `xml:"mediaPresentationDuration,attr"`
+	AvailabilityStartTime     *string `xml:"availabilityStartTime,attr,omitempty"`
 	MinBufferTime             *string `xml:"minBufferTime,attr"`
 	BaseURL                   string  `xml:"BaseURL,omitempty"`
 	period                    *Period
@@ -218,19 +219,29 @@ type AudioChannelConfiguration struct {
 
 // Creates a new MPD object.
 // profile - DASH Profile (Live or OnDemand).
-// mediaPresentationDuration - Media Presentation Duration (i.e. PT6M16S).
-// minBufferTime - Min Buffer Time (i.e. PT1.97S).
-func NewMPD(profile DashProfile, mediaPresentationDuration string, minBufferTime string) *MPD {
+// attributes - set of MPD root attributes
+//  - mediaPresentationDuration - Media Presentation Duration (i.e. PT6M16S).
+//  - minBufferTime - Min Buffer Time (i.e. PT1.97S).
+//  - availabilityStartTime - the start time (i.e. 2017-10-18T16:23:54Z), the anchor for the MPD in wall-clock time. The value is also known as AST. For MPD@type='dynamic' this attribute shall be present.
+func NewMPD(profile DashProfile, attributes map[string]string) *MPD {
 	period := &Period{}
 	return &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
 		Profiles: Strptr((string)(profile)),
-		Type:     Strptr("static"),
-		MediaPresentationDuration: Strptr(mediaPresentationDuration),
-		MinBufferTime:             Strptr(minBufferTime),
+		Type:     Strptr(defaultValue(attributes["type"], "static")),
+		MediaPresentationDuration: EmptyStrPtr(attributes["mediaPresentationDuration"]),
+		MinBufferTime:             EmptyStrPtr(attributes["minBufferTime"]),
+		AvailabilityStartTime:     EmptyStrPtr(attributes["availabilityStartTime"]),
 		period:                    period,
 		Periods:                   []*Period{period},
 	}
+}
+
+func defaultValue(value string, defaultVal string) string {
+	if value == "" {
+		return defaultVal
+	}
+	return value
 }
 
 // AddNewPeriod creates a new Period and make it the currently active one.

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -24,6 +24,15 @@ const (
 	DASH_PROFILE_HBBTV_1_5_LIVE DashProfile = "urn:hbbtv:dash:profile:isoff-live:2012,urn:mpeg:dash:profile:isoff-live:2011"
 )
 
+// Constants for DASH mpd tag
+const (
+	ATTR_TYPE                        = "type"
+	ATTR_TYPE_STATIC                 = "static"
+	ATTR_MEDIA_PRESENTATION_DURATION = "mediaPresentationDuration"
+	ATTR_MIN_BUFFER_TIME             = "minBufferTime"
+	ATTR_AVAILABILITY_START_TIME     = "availabilityStartTime"
+)
+
 type AudioChannelConfigurationScheme string
 
 const (
@@ -228,10 +237,10 @@ func NewMPD(profile DashProfile, attributes map[string]string) *MPD {
 	return &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
 		Profiles: Strptr((string)(profile)),
-		Type:     Strptr(defaultValue(attributes["type"], "static")),
-		MediaPresentationDuration: EmptyStrPtr(attributes["mediaPresentationDuration"]),
-		MinBufferTime:             EmptyStrPtr(attributes["minBufferTime"]),
-		AvailabilityStartTime:     EmptyStrPtr(attributes["availabilityStartTime"]),
+		Type:     Strptr(defaultValue(attributes[ATTR_TYPE], ATTR_TYPE_STATIC)),
+		MediaPresentationDuration: EmptyStrPtr(attributes[ATTR_MEDIA_PRESENTATION_DURATION]),
+		MinBufferTime:             EmptyStrPtr(attributes[ATTR_MIN_BUFFER_TIME]),
+		AvailabilityStartTime:     EmptyStrPtr(attributes[ATTR_AVAILABILITY_START_TIME]),
 		period:                    period,
 		Periods:                   []*Period{period},
 	}

--- a/mpd/mpd_read_write_test.go
+++ b/mpd/mpd_read_write_test.go
@@ -39,7 +39,7 @@ func TestReadingManifests(t *testing.T) {
 }
 
 func TestNewMPDLiveWriteToString(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 
 	xmlStr, err := m.WriteToString()
 	require.Nil(t, err)
@@ -52,7 +52,7 @@ func TestNewMPDLiveWriteToString(t *testing.T) {
 }
 
 func TestNewMPDOnDemandWriteToString(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_ONDEMAND, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_ONDEMAND)
 
 	xmlStr, err := m.WriteToString()
 	require.Nil(t, err)
@@ -65,7 +65,7 @@ func TestNewMPDOnDemandWriteToString(t *testing.T) {
 }
 
 func TestAddNewAdaptationSetAudioWriteToString(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 
 	m.AddNewAdaptationSetAudioWithID("7357", DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
 
@@ -82,7 +82,7 @@ func TestAddNewAdaptationSetAudioWriteToString(t *testing.T) {
 }
 
 func TestAddNewAdaptationSetVideoWriteToString(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 
 	m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
@@ -99,7 +99,7 @@ func TestAddNewAdaptationSetVideoWriteToString(t *testing.T) {
 }
 
 func TestAddNewAdaptationSetSubtitleWriteToString(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 
 	m.AddNewAdaptationSetSubtitleWithID("7357", DASH_MIME_TYPE_SUBTITLE_VTT, VALID_LANG)
 
@@ -117,7 +117,7 @@ func TestAddNewAdaptationSetSubtitleWriteToString(t *testing.T) {
 
 func TestExampleAddNewPeriod(t *testing.T) {
 	// a new MPD is created with a single Period
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 
 	// you can add content to the Period
 	p := m.GetCurrentPeriod()
@@ -143,7 +143,7 @@ func TestExampleAddNewPeriod(t *testing.T) {
 }
 
 func LiveProfile() *MPD {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 
 	audioAS, _ := m.AddNewAdaptationSetAudioWithID("7357", DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
 
@@ -197,7 +197,7 @@ func TestFullLiveProfileWriteToFile(t *testing.T) {
 }
 
 func HbbTVProfile() *MPD {
-	m := NewMPD(DASH_PROFILE_HBBTV_1_5_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_HBBTV_1_5_LIVE)
 
 	audioAS, _ := m.AddNewAdaptationSetAudioWithID("7357", DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
 
@@ -251,7 +251,12 @@ func TestFullHbbTVProfileWriteToFile(t *testing.T) {
 }
 
 func OnDemandProfile() *MPD {
-	m := NewMPD(DASH_PROFILE_ONDEMAND, "PT30S", VALID_MIN_BUFFER_TIME)
+	var attributes map[string]string
+	attributes = make(map[string]string)
+
+	attributes["mediaPresentationDuration"] = "PT30S"
+	attributes["minBufferTime"] = VALID_MIN_BUFFER_TIME
+	m := CreateMPDWithArgs(DASH_PROFILE_ONDEMAND, attributes)
 
 	audioAS, _ := m.AddNewAdaptationSetAudioWithID("7357", DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, "und")
 

--- a/mpd/mpd_read_write_test.go
+++ b/mpd/mpd_read_write_test.go
@@ -254,8 +254,8 @@ func OnDemandProfile() *MPD {
 	var attributes map[string]string
 	attributes = make(map[string]string)
 
-	attributes["mediaPresentationDuration"] = "PT30S"
-	attributes["minBufferTime"] = VALID_MIN_BUFFER_TIME
+	attributes[ATTR_MEDIA_PRESENTATION_DURATION] = "PT30S"
+	attributes[ATTR_MIN_BUFFER_TIME] = VALID_MIN_BUFFER_TIME
 	m := CreateMPDWithArgs(DASH_PROFILE_ONDEMAND, attributes)
 
 	audioAS, _ := m.AddNewAdaptationSetAudioWithID("7357", DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, "und")

--- a/mpd/mpd_test.go
+++ b/mpd/mpd_test.go
@@ -48,13 +48,52 @@ const (
 	VALID_ROLE                        string = "main"
 )
 
+func CreateMPD(profile DashProfile) *MPD {
+	var attributes map[string]string
+	attributes = make(map[string]string)
+
+	attributes["mediaPresentationDuration"] = VALID_MEDIA_PRESENTATION_DURATION
+	attributes["minBufferTime"] = VALID_MIN_BUFFER_TIME
+	return CreateMPDWithArgs(profile, attributes)
+}
+
+func CreateMPDWithArgs(profile DashProfile, attributes map[string]string) *MPD {
+	return NewMPD(profile, attributes)
+}
+
 func TestNewMPDLive(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	require.NotNil(t, m)
 	expectedMPD := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
 		Profiles: Strptr((string)(DASH_PROFILE_LIVE)),
 		Type:     Strptr("static"),
+		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
+		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
+		period:                    &Period{},
+		Periods:                   []*Period{{}},
+	}
+	require.Equal(t, expectedMPD, m)
+}
+
+func TestNewDynamicMPDLive(t *testing.T) {
+	var attributes map[string]string
+	attributes = make(map[string]string)
+
+	ast := "2017-10-18T16:23:54Z"
+
+	attributes["availabilityStartTime"] = ast
+	attributes["type"] = "dynamic"
+	attributes["mediaPresentationDuration"] = VALID_MEDIA_PRESENTATION_DURATION
+	attributes["minBufferTime"] = VALID_MIN_BUFFER_TIME
+
+	m := CreateMPDWithArgs(DASH_PROFILE_LIVE, attributes)
+	require.NotNil(t, m)
+	expectedMPD := &MPD{
+		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
+		Profiles: Strptr((string)(DASH_PROFILE_LIVE)),
+		Type:     Strptr("dynamic"),
+		AvailabilityStartTime:     Strptr(ast),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
 		period:                    &Period{},
@@ -88,7 +127,7 @@ func TestWidevineContentProtection_ImplementsInterface(t *testing.T) {
 }
 
 func TestNewMPDLiveWithBaseURLInMPD(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	m.BaseURL = VALID_BASE_URL_VIDEO
 	require.NotNil(t, m)
 	expectedMPD := &MPD{
@@ -105,7 +144,7 @@ func TestNewMPDLiveWithBaseURLInMPD(t *testing.T) {
 }
 
 func TestNewMPDLiveWithBaseURLInPeriod(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	m.period.BaseURL = VALID_BASE_URL_VIDEO
 	require.NotNil(t, m)
 	period := &Period{
@@ -124,7 +163,7 @@ func TestNewMPDLiveWithBaseURLInPeriod(t *testing.T) {
 }
 
 func TestNewMPDHbbTV(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_HBBTV_1_5_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_HBBTV_1_5_LIVE)
 	require.NotNil(t, m)
 	expectedMPD := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
@@ -139,7 +178,7 @@ func TestNewMPDHbbTV(t *testing.T) {
 }
 
 func TestNewMPDOnDemand(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_ONDEMAND, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_ONDEMAND)
 	require.NotNil(t, m)
 	expectedMPD := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
@@ -154,7 +193,7 @@ func TestNewMPDOnDemand(t *testing.T) {
 }
 
 func TestAddNewAdaptationSetAudio(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	as, err := m.AddNewAdaptationSetAudio(DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
 	require.NotNil(t, as)
 	require.Nil(t, err)
@@ -188,7 +227,7 @@ func TestAddNewAdaptationSetAudio(t *testing.T) {
 }
 
 func TestAddNewAdaptationSetAudioWithID(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	as, err := m.AddNewAdaptationSetAudioWithID("7357", DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
 	require.NotNil(t, as)
 	require.Nil(t, err)
@@ -222,7 +261,7 @@ func TestAddNewAdaptationSetAudioWithID(t *testing.T) {
 }
 
 func TestAddNewAdaptationSetVideo(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 
 	as, err := m.AddNewAdaptationSetVideo(DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 	require.NotNil(t, as)
@@ -256,7 +295,7 @@ func TestAddNewAdaptationSetVideo(t *testing.T) {
 }
 
 func TestAddNewAdaptationSetVideoWithID(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 
 	as, err := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 	require.NotNil(t, as)
@@ -290,7 +329,7 @@ func TestAddNewAdaptationSetVideoWithID(t *testing.T) {
 }
 
 func TestAddNewAdaptationSetSubtitle(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 
 	as, err := m.AddNewAdaptationSetSubtitle(DASH_MIME_TYPE_SUBTITLE_VTT, VALID_LANG)
 	require.NotNil(t, as)
@@ -305,7 +344,7 @@ func TestAddNewAdaptationSetSubtitle(t *testing.T) {
 }
 
 func TestAddNewAdaptationSetSubtitleWithID(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 
 	as, err := m.AddNewAdaptationSetSubtitleWithID("7357", DASH_MIME_TYPE_SUBTITLE_VTT, VALID_LANG)
 	require.NotNil(t, as)
@@ -321,7 +360,7 @@ func TestAddNewAdaptationSetSubtitleWithID(t *testing.T) {
 }
 
 func TestAddAdaptationSetErrorNil(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 
 	err := m.period.addAdaptationSet(nil)
 	require.NotNil(t, err)
@@ -329,7 +368,7 @@ func TestAddAdaptationSetErrorNil(t *testing.T) {
 }
 
 func TestAddNewContentProtectionRoot_Legacy(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	s, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	cp, err := s.AddNewContentProtectionRootLegacyUUID(VALID_DEFAULT_KID_HEX)
@@ -346,7 +385,7 @@ func TestAddNewContentProtectionRoot_Legacy(t *testing.T) {
 }
 
 func TestAddNewContentProtectionRoot(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	s, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	cp, err := s.AddNewContentProtectionRoot(VALID_DEFAULT_KID_HEX)
@@ -371,7 +410,7 @@ type TestProprietaryContentProtection struct {
 func (s *TestProprietaryContentProtection) ContentProtected() {}
 
 func TestAddNewContentProtection_Proprietary(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	as, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	cp := &ContentProtection{
@@ -386,7 +425,7 @@ func TestAddNewContentProtection_Proprietary(t *testing.T) {
 }
 
 func TestAddNewContentProtectionRootErrorInvalidLengthDefaultKID(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	s, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	cp, err := s.AddNewContentProtectionRoot("invalidkid")
@@ -396,7 +435,7 @@ func TestAddNewContentProtectionRootErrorInvalidLengthDefaultKID(t *testing.T) {
 }
 
 func TestAddNewContentProtectionRootErrorEmptyDefaultKID(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	s, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	cp, err := s.AddNewContentProtectionRoot("")
@@ -406,7 +445,7 @@ func TestAddNewContentProtectionRootErrorEmptyDefaultKID(t *testing.T) {
 }
 
 func TestAddNewContentProtectionSchemeWidevineWithPSSH(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	s, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	cp, err := s.AddNewContentProtectionSchemeWidevineWithPSSH(getValidWVHeaderBytes())
@@ -421,7 +460,7 @@ func TestAddNewContentProtectionSchemeWidevineWithPSSH(t *testing.T) {
 }
 
 func TestAddNewContentProtectionSchemeWidevine(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	s, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	cp, err := s.AddNewContentProtectionSchemeWidevine()
@@ -433,7 +472,7 @@ func TestAddNewContentProtectionSchemeWidevine(t *testing.T) {
 }
 
 func TestAddNewContentProtectionSchemePlayreadyErrorEmptyPRO(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	s, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	cp, err := s.AddNewContentProtectionSchemePlayready("")
@@ -443,7 +482,7 @@ func TestAddNewContentProtectionSchemePlayreadyErrorEmptyPRO(t *testing.T) {
 }
 
 func TestAddNewContentProtectionSchemePlayready(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	s, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	cp, err := s.AddNewContentProtectionSchemePlayready(VALID_PLAYREADY_PRO)
@@ -459,7 +498,7 @@ func TestAddNewContentProtectionSchemePlayready(t *testing.T) {
 }
 
 func TestAddNewContentProtectionSchemePlayreadyV10ErrorEmptyPRO(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	s, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	cp, err := s.AddNewContentProtectionSchemePlayreadyV10("")
@@ -469,7 +508,7 @@ func TestAddNewContentProtectionSchemePlayreadyV10ErrorEmptyPRO(t *testing.T) {
 }
 
 func TestAddNewContentProtectionSchemePlayreadyV10(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	s, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	cp, err := s.AddNewContentProtectionSchemePlayreadyV10(VALID_PLAYREADY_PRO)
@@ -485,7 +524,7 @@ func TestAddNewContentProtectionSchemePlayreadyV10(t *testing.T) {
 }
 
 func TestAddNewContentProtectionSchemePlayreadyWithPSSH(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	s, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	cp, err := s.AddNewContentProtectionSchemePlayreadyWithPSSH(VALID_PLAYREADY_PRO)
@@ -503,7 +542,7 @@ func TestAddNewContentProtectionSchemePlayreadyWithPSSH(t *testing.T) {
 }
 
 func TestAddNewContentProtectionSchemePlayreadyV10WithPSSH(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	s, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	cp, err := s.AddNewContentProtectionSchemePlayreadyV10WithPSSH(VALID_PLAYREADY_PRO)
@@ -521,7 +560,7 @@ func TestAddNewContentProtectionSchemePlayreadyV10WithPSSH(t *testing.T) {
 }
 
 func TestSetNewSegmentTemplate(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	audioAS, _ := m.AddNewAdaptationSetAudioWithID("7357", DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
 	st, err := audioAS.SetNewSegmentTemplate(VALID_DURATION, VALID_INIT_PATH_AUDIO, VALID_MEDIA_PATH_AUDIO, VALID_START_NUMBER, VALID_TIMESCALE)
 	require.NotNil(t, st)
@@ -544,7 +583,7 @@ func TestSetNewSegmentTemplateErrorNoDASHProfile(t *testing.T) {
 }
 
 func TestAddRepresentationAudio(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	audioAS, _ := m.AddNewAdaptationSetAudioWithID("7357", DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
 
 	r, err := audioAS.AddNewRepresentationAudio(VALID_AUDIO_SAMPLE_RATE, VALID_AUDIO_BITRATE, VALID_AUDIO_CODEC, VALID_AUDIO_ID)
@@ -554,7 +593,7 @@ func TestAddRepresentationAudio(t *testing.T) {
 }
 
 func TestAddAudioChannelConfiguration(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_HBBTV_1_5_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_HBBTV_1_5_LIVE)
 	audioAS, _ := m.AddNewAdaptationSetAudioWithID("7357", DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
 
 	r, _ := audioAS.AddNewRepresentationAudio(VALID_AUDIO_SAMPLE_RATE, VALID_AUDIO_BITRATE, VALID_AUDIO_CODEC, VALID_AUDIO_ID)
@@ -566,7 +605,7 @@ func TestAddAudioChannelConfiguration(t *testing.T) {
 }
 
 func TestAddRepresentationVideo(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	videoAS, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	r, err := videoAS.AddNewRepresentationVideo(VALID_VIDEO_BITRATE, VALID_VIDEO_CODEC, VALID_VIDEO_ID, VALID_VIDEO_FRAMERATE, VALID_VIDEO_WIDTH, VALID_VIDEO_HEIGHT)
@@ -576,7 +615,7 @@ func TestAddRepresentationVideo(t *testing.T) {
 }
 
 func TestAddRepresentationSubtitle(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 
 	subtitleAS, _ := m.AddNewAdaptationSetSubtitleWithID("7357", DASH_MIME_TYPE_SUBTITLE_VTT, VALID_LANG)
 
@@ -587,7 +626,7 @@ func TestAddRepresentationSubtitle(t *testing.T) {
 }
 
 func TestAddRepresentationErrorNil(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	videoAS, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	err := videoAS.addRepresentation(nil)
@@ -596,7 +635,7 @@ func TestAddRepresentationErrorNil(t *testing.T) {
 }
 
 func TestAddRole(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	audioAS, _ := m.AddNewAdaptationSetAudioWithID("7357", DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
 
 	r, err := audioAS.AddNewRole("urn:mpeg:dash:role:2011", VALID_ROLE)
@@ -606,7 +645,7 @@ func TestAddRole(t *testing.T) {
 }
 
 func TestSetSegmentTemplateErrorNil(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_LIVE)
 	audioAS, _ := m.AddNewAdaptationSetAudioWithID("7357", DASH_MIME_TYPE_AUDIO_MP4, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP, VALID_LANG)
 	err := audioAS.setSegmentTemplate(nil)
 	require.NotNil(t, err)
@@ -614,7 +653,7 @@ func TestSetSegmentTemplateErrorNil(t *testing.T) {
 }
 
 func TestSetNewBaseURLVideo(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_ONDEMAND, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_ONDEMAND)
 	videoAS, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	r, _ := videoAS.AddNewRepresentationVideo(VALID_VIDEO_BITRATE, VALID_VIDEO_CODEC, VALID_VIDEO_ID, VALID_VIDEO_FRAMERATE, VALID_VIDEO_WIDTH, VALID_VIDEO_HEIGHT)
@@ -625,7 +664,7 @@ func TestSetNewBaseURLVideo(t *testing.T) {
 }
 
 func TestSetNewBaseURLSubtitle(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_ONDEMAND, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_ONDEMAND)
 	subtitleAS, _ := m.AddNewAdaptationSetSubtitleWithID("7357", DASH_MIME_TYPE_SUBTITLE_VTT, VALID_LANG)
 
 	r, _ := subtitleAS.AddNewRepresentationSubtitle(VALID_SUBTITLE_BANDWIDTH, VALID_SUBTITLE_ID)
@@ -656,7 +695,7 @@ func TestSetNewBaseURLErrorNoDASHProfile(t *testing.T) {
 }
 
 func TestSetNewBaseURLErrorEmpty(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_ONDEMAND, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_ONDEMAND)
 	videoAS, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	r, _ := videoAS.AddNewRepresentationVideo(VALID_VIDEO_BITRATE, VALID_VIDEO_CODEC, VALID_VIDEO_ID, VALID_VIDEO_FRAMERATE, VALID_VIDEO_WIDTH, VALID_VIDEO_HEIGHT)
@@ -668,7 +707,7 @@ func TestSetNewBaseURLErrorEmpty(t *testing.T) {
 }
 
 func TestSetNewSegmentBase(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_ONDEMAND, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_ONDEMAND)
 	videoAS, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	r, _ := videoAS.AddNewRepresentationVideo(VALID_VIDEO_BITRATE, VALID_VIDEO_CODEC, VALID_VIDEO_ID, VALID_VIDEO_FRAMERATE, VALID_VIDEO_WIDTH, VALID_VIDEO_HEIGHT)
@@ -698,7 +737,7 @@ func TestSetNewSegmentBaseErrorNoDASHProfile(t *testing.T) {
 }
 
 func TestSetSegmentBaseErrorNil(t *testing.T) {
-	m := NewMPD(DASH_PROFILE_ONDEMAND, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
+	m := CreateMPD(DASH_PROFILE_ONDEMAND)
 	videoAS, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
 	r, _ := videoAS.AddNewRepresentationVideo(VALID_VIDEO_BITRATE, VALID_VIDEO_CODEC, VALID_VIDEO_ID, VALID_VIDEO_FRAMERATE, VALID_VIDEO_WIDTH, VALID_VIDEO_HEIGHT)

--- a/mpd/mpd_test.go
+++ b/mpd/mpd_test.go
@@ -52,8 +52,8 @@ func CreateMPD(profile DashProfile) *MPD {
 	var attributes map[string]string
 	attributes = make(map[string]string)
 
-	attributes["mediaPresentationDuration"] = VALID_MEDIA_PRESENTATION_DURATION
-	attributes["minBufferTime"] = VALID_MIN_BUFFER_TIME
+	attributes[ATTR_MEDIA_PRESENTATION_DURATION] = VALID_MEDIA_PRESENTATION_DURATION
+	attributes[ATTR_MIN_BUFFER_TIME] = VALID_MIN_BUFFER_TIME
 	return CreateMPDWithArgs(profile, attributes)
 }
 
@@ -67,7 +67,7 @@ func TestNewMPDLive(t *testing.T) {
 	expectedMPD := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
 		Profiles: Strptr((string)(DASH_PROFILE_LIVE)),
-		Type:     Strptr("static"),
+		Type:     Strptr(ATTR_TYPE_STATIC),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
 		period:                    &Period{},
@@ -82,17 +82,17 @@ func TestNewDynamicMPDLive(t *testing.T) {
 
 	ast := "2017-10-18T16:23:54Z"
 
-	attributes["availabilityStartTime"] = ast
-	attributes["type"] = "dynamic"
-	attributes["mediaPresentationDuration"] = VALID_MEDIA_PRESENTATION_DURATION
-	attributes["minBufferTime"] = VALID_MIN_BUFFER_TIME
+	attributes[ATTR_AVAILABILITY_START_TIME] = ast
+	attributes[ATTR_TYPE] = ATTR_TYPE_DYNAMIC
+	attributes[ATTR_MEDIA_PRESENTATION_DURATION] = VALID_MEDIA_PRESENTATION_DURATION
+	attributes[ATTR_MIN_BUFFER_TIME] = VALID_MIN_BUFFER_TIME
 
 	m := CreateMPDWithArgs(DASH_PROFILE_LIVE, attributes)
 	require.NotNil(t, m)
 	expectedMPD := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
 		Profiles: Strptr((string)(DASH_PROFILE_LIVE)),
-		Type:     Strptr("dynamic"),
+		Type:     Strptr(ATTR_TYPE_DYNAMIC),
 		AvailabilityStartTime:     Strptr(ast),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
@@ -133,7 +133,7 @@ func TestNewMPDLiveWithBaseURLInMPD(t *testing.T) {
 	expectedMPD := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
 		Profiles: Strptr((string)(DASH_PROFILE_LIVE)),
-		Type:     Strptr("static"),
+		Type:     Strptr(ATTR_TYPE_STATIC),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
 		period:                    &Period{},
@@ -153,7 +153,7 @@ func TestNewMPDLiveWithBaseURLInPeriod(t *testing.T) {
 	expectedMPD := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
 		Profiles: Strptr((string)(DASH_PROFILE_LIVE)),
-		Type:     Strptr("static"),
+		Type:     Strptr(ATTR_TYPE_STATIC),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
 		period:                    period,
@@ -168,7 +168,7 @@ func TestNewMPDHbbTV(t *testing.T) {
 	expectedMPD := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
 		Profiles: Strptr((string)(DASH_PROFILE_HBBTV_1_5_LIVE)),
-		Type:     Strptr("static"),
+		Type:     Strptr(ATTR_TYPE_STATIC),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
 		period:                    &Period{},
@@ -183,7 +183,7 @@ func TestNewMPDOnDemand(t *testing.T) {
 	expectedMPD := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
 		Profiles: Strptr((string)(DASH_PROFILE_ONDEMAND)),
-		Type:     Strptr("static"),
+		Type:     Strptr(ATTR_TYPE_STATIC),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
 		period:                    &Period{},
@@ -571,7 +571,7 @@ func TestSetNewSegmentTemplateErrorNoDASHProfile(t *testing.T) {
 	m := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
 		Profiles: nil,
-		Type:     Strptr("static"),
+		Type:     Strptr(ATTR_TYPE_STATIC),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
 		period:                    &Period{},
@@ -678,7 +678,7 @@ func TestSetNewBaseURLErrorNoDASHProfile(t *testing.T) {
 	m := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
 		Profiles: nil,
-		Type:     Strptr("static"),
+		Type:     Strptr(ATTR_TYPE_STATIC),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
 		period:                    &Period{},
@@ -721,7 +721,7 @@ func TestSetNewSegmentBaseErrorNoDASHProfile(t *testing.T) {
 	m := &MPD{
 		XMLNs:    Strptr("urn:mpeg:dash:schema:mpd:2011"),
 		Profiles: nil,
-		Type:     Strptr("static"),
+		Type:     Strptr(ATTR_TYPE_STATIC),
 		MediaPresentationDuration: Strptr(VALID_MEDIA_PRESENTATION_DURATION),
 		MinBufferTime:             Strptr(VALID_MIN_BUFFER_TIME),
 		period:                    &Period{},

--- a/mpd/segment_list_test.go
+++ b/mpd/segment_list_test.go
@@ -53,8 +53,8 @@ func getSegmentListMPD() *MPD {
 	var attributes map[string]string
 	attributes = make(map[string]string)
 
-	attributes["mediaPresentationDuration"] = "PT30.016S"
-	attributes["minBufferTime"] = "PT2.000S"
+	attributes[ATTR_MEDIA_PRESENTATION_DURATION] = "PT30.016S"
+	attributes[ATTR_MIN_BUFFER_TIME] = "PT2.000S"
 
 	m := CreateMPDWithArgs(DASH_PROFILE_LIVE, attributes)
 	m.period.BaseURL = "http://localhost:8002/dash/"

--- a/mpd/segment_list_test.go
+++ b/mpd/segment_list_test.go
@@ -50,7 +50,13 @@ func TestSegmentListDeserialization(t *testing.T) {
 }
 
 func getSegmentListMPD() *MPD {
-	m := NewMPD(DASH_PROFILE_LIVE, "PT30.016S", "PT2.000S")
+	var attributes map[string]string
+	attributes = make(map[string]string)
+
+	attributes["mediaPresentationDuration"] = "PT30.016S"
+	attributes["minBufferTime"] = "PT2.000S"
+
+	m := CreateMPDWithArgs(DASH_PROFILE_LIVE, attributes)
 	m.period.BaseURL = "http://localhost:8002/dash/"
 
 	aas, _ := m.AddNewAdaptationSetAudioWithID("1", "audio/mp4", true, 1, "English")

--- a/mpd/segment_timeline_test.go
+++ b/mpd/segment_timeline_test.go
@@ -52,8 +52,8 @@ func TestSegmentTimelineDeserialization(t *testing.T) {
 func getMultiPeriodSegmentTimelineMPD() *MPD {
 	var attributes map[string]string
 	attributes = make(map[string]string)
-	attributes["mediaPresentationDuration"] = "PT65.063S"
-	attributes["minBufferTime"] = "PT2.000S"
+	attributes[ATTR_MEDIA_PRESENTATION_DURATION] = "PT65.063S"
+	attributes[ATTR_MIN_BUFFER_TIME] = "PT2.000S"
 
 	m := CreateMPDWithArgs(DASH_PROFILE_LIVE, attributes)
 	for i := 0; i < 4; i++ {
@@ -104,8 +104,8 @@ func getMultiPeriodSegmentTimelineMPD() *MPD {
 func getSegmentTimelineMPD() *MPD {
 	var attributes map[string]string
 	attributes = make(map[string]string)
-	attributes["mediaPresentationDuration"] = "PT65.063S"
-	attributes["minBufferTime"] = "PT2.000S"
+	attributes[ATTR_MEDIA_PRESENTATION_DURATION] = "PT65.063S"
+	attributes[ATTR_MIN_BUFFER_TIME] = "PT2.000S"
 
 	m := CreateMPDWithArgs(DASH_PROFILE_LIVE, attributes)
 	m.period.BaseURL = "http://localhost:8002/public/"

--- a/mpd/segment_timeline_test.go
+++ b/mpd/segment_timeline_test.go
@@ -50,7 +50,12 @@ func TestSegmentTimelineDeserialization(t *testing.T) {
 }
 
 func getMultiPeriodSegmentTimelineMPD() *MPD {
-	m := NewMPD(DASH_PROFILE_LIVE, "PT65.063S", "PT2.000S")
+	var attributes map[string]string
+	attributes = make(map[string]string)
+	attributes["mediaPresentationDuration"] = "PT65.063S"
+	attributes["minBufferTime"] = "PT2.000S"
+
+	m := CreateMPDWithArgs(DASH_PROFILE_LIVE, attributes)
 	for i := 0; i < 4; i++ {
 		if i > 0 {
 			m.AddNewPeriod()
@@ -97,7 +102,12 @@ func getMultiPeriodSegmentTimelineMPD() *MPD {
 }
 
 func getSegmentTimelineMPD() *MPD {
-	m := NewMPD(DASH_PROFILE_LIVE, "PT65.063S", "PT2.000S")
+	var attributes map[string]string
+	attributes = make(map[string]string)
+	attributes["mediaPresentationDuration"] = "PT65.063S"
+	attributes["minBufferTime"] = "PT2.000S"
+
+	m := CreateMPDWithArgs(DASH_PROFILE_LIVE, attributes)
 	m.period.BaseURL = "http://localhost:8002/public/"
 
 	aas, _ := m.AddNewAdaptationSetAudioWithID("1", "audio/mp4", true, 1, "English")


### PR DESCRIPTION
* Changed the `NewMPD` constructor to accept a map of attributes (easier to expand to new attributes)
* Added a new helper function `EmptyStrPtr` to work with an empty string which I need to be seen as `nil` pointers.
* Added a new test case for availabilityStartTime
* Fixed existent tests