### PR TITLE
Fix marshaling ContentProtectioner & unmarshaling in AdaptationSet

### DIFF
--- a/mpd/mpd_test.go
+++ b/mpd/mpd_test.go
@@ -386,7 +386,7 @@ func TestAddNewContentProtectionRoot(t *testing.T) {
 }
 
 type TestProprietaryContentProtection struct {
-	ContentProtection
+	ContentProtectionMarshal
 	TestAttrA string `xml:"a,attr,omitempty"`
 	TestAttrB string `xml:"b,attr,omitempty"`
 }
@@ -397,7 +397,7 @@ func TestAddNewContentProtection_Proprietary(t *testing.T) {
 	m := NewMPD(DASH_PROFILE_LIVE, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
 	as, _ := m.AddNewAdaptationSetVideoWithID("7357", DASH_MIME_TYPE_VIDEO_MP4, VALID_SCAN_TYPE, VALID_SEGMENT_ALIGNMENT, VALID_START_WITH_SAP)
 
-	cp := &ContentProtection{
+	cp := &ContentProtectionMarshal{
 		SchemeIDURI: Strptr(CONTENT_PROTECTION_ROOT_SCHEME_ID_URI),
 	}
 


### PR DESCRIPTION
**Description of PR/What business logic are you adding?**
* Add `UnmarshalXML` method to `AdaptationSet` for custom unmarshaling which allows detection of `ContentProtectioner` type based on `schemeIdUri`
    * This actually fixes a bug where without the `UnmarshalXML` method there is no way for the `xml.Decoder` to know which struct to use when it identifies a `ContentProtection` tag.

* Add structs `ContentProtectionMarshal`, `CENCContentProtectionMarshal`, `PlayreadyContentProtectionMarshal`, `WidevineContentProtectionMarshal` to work around https://github.com/golang/go/issues/9519
* Add `MarshalXML` method to all `ContentProtectioner` receiver to allow `xml.Encoder` to use the marshaling structs
* Update `TestAddNewContentProtection_Proprietary` to use `ContentProtectionMarshal`