### PR TITLE
Proper GoModules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/zencoder/go-dash
+module github.com/zencoder/go-dash/v3


### PR DESCRIPTION
Your GoModules support is not working now. 
Please add "v3" to go.mod following https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher.
Also you should carefully replace import paths for your own packages. For example:
https://github.com/zencoder/go-dash/blob/master/mpd/mpd.go
In this file you import "github.com/zencoder/go-dash/helpers/ptrs", it should be replaced with "github.com/zencoder/go-dash/v3/helpers/ptrs".
According to https://github.com/golang/go/wiki/Modules#automatic-migration-from-prior-dependency-managers
Good luck :)