### PR TITLE
open file with os.O_TRUNC when writing to file

### DIFF
--- a/mpd/fixtures/truncate.mpd
+++ b/mpd/fixtures/truncate.mpd
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" minBufferTime="PT2S" availabilityStartTime="2019-12-03T20:57:14Z" minimumUpdatePeriod="PT5S" publishTime="2019-12-03T21:05:05Z" timeShiftBufferDepth="PT120S">
+  <Period id="0">
+    <AdaptationSet frameRate="90000/3000" id="0" segmentAlignment="true" maxWidth="720" contentType="video">
+      <Representation sar="1:1" mimeType="video/mp4" bandwidth="306235" codecs="avc1.42c01e" height="480" id="0" width="720">
+        <SegmentTemplate initialization="video_0/init.mp4" media="video_0/media_$Number$.m4s" startNumber="1" timescale="90000">
+          <SegmentTimeline>
+            <S t="127920" d="540000" r="4"></S>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation sar="1:1" mimeType="video/mp4" bandwidth="201655" codecs="avc1.42c01e" height="360" id="2" width="640">
+        <SegmentTemplate initialization="video_1/init.mp4" media="video_1/media_$Number$.m4s" startNumber="1" timescale="90000">
+          <SegmentTimeline>
+            <S t="127920" d="540000" r="4"></S>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" segmentAlignment="true" contentType="audio">
+      <Representation mimeType="audio/mp4" audioSamplingRate="48000" bandwidth="97994" codecs="mp4a.40.2" id="1">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+        <SegmentTemplate initialization="audio_0/init.mp4" media="audio_0/media_$Number$.m4s" startNumber="1" timescale="90000">
+          <SegmentTimeline>
+            <S t="126000" d="414720"></S>
+            <S t="540720" d="539520" r="3"></S>
+            <S t="2698800" d="128640"></S>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation mimeType="audio/mp4" audioSamplingRate="48000" bandwidth="97994" codecs="mp4a.40.2" id="3">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+        <SegmentTemplate initialization="audio_1/init.mp4" media="audio_1/media_$Number$.m4s" startNumber="1" timescale="90000">
+          <SegmentTimeline>
+            <S t="126000" d="414720"></S>
+            <S t="540720" d="539520" r="3"></S>
+            <S t="2698800" d="128640"></S>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <Period id="1" start="PT31.421333333S">
+    <AdaptationSet frameRate="90000/3000" id="0" segmentAlignment="true" maxWidth="720" contentType="video">
+      <Representation sar="1:1" mimeType="video/mp4" bandwidth="311792" codecs="avc1.42c01e" height="480" id="0" width="720">
+        <SegmentTemplate initialization="video_0/init.mp4" media="video_0/media_$Number$.m4s" startNumber="6" timescale="90000">
+          <SegmentTimeline>
+            <S t="2827920" d="540000" r="9"></S>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation sar="1:1" mimeType="video/mp4" bandwidth="209067" codecs="avc1.42c01e" height="360" id="2" width="640">
+        <SegmentTemplate initialization="video_1/init.mp4" media="video_1/media_$Number$.m4s" startNumber="6" timescale="90000">
+          <SegmentTimeline>
+            <S t="2827920" d="540000" r="9"></S>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" segmentAlignment="true" contentType="audio">
+      <Representation mimeType="audio/mp4" audioSamplingRate="48000" bandwidth="97888" codecs="mp4a.40.2" id="1">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+        <SegmentTemplate initialization="audio_0/init.mp4" media="audio_0/media_$Number$.m4s" startNumber="7" timescale="90000">
+          <SegmentTimeline>
+            <S t="2827440" d="540000" r="9"></S>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation mimeType="audio/mp4" audioSamplingRate="48000" bandwidth="97888" codecs="mp4a.40.2" id="3">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+        <SegmentTemplate initialization="audio_1/init.mp4" media="audio_1/media_$Number$.m4s" startNumber="7" timescale="90000">
+          <SegmentTimeline>
+            <S t="2827440" d="540000" r="9"></S>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <UTCTiming value="https://time.akamai.com/?iso"></UTCTiming>
+</MPD>

--- a/mpd/fixtures/truncate_short.mpd
+++ b/mpd/fixtures/truncate_short.mpd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" minBufferTime="PT2S" availabilityStartTime="2019-12-03T20:57:14Z" minimumUpdatePeriod="PT5S" publishTime="2019-12-03T21:05:05Z" timeShiftBufferDepth="PT120S">
+  <Period id="1" start="PT31.421333333S">
+    <AdaptationSet frameRate="90000/3000" id="0" segmentAlignment="true" maxWidth="720" contentType="video">
+      <Representation sar="1:1" mimeType="video/mp4" bandwidth="311792" codecs="avc1.42c01e" height="480" id="0" width="720">
+        <SegmentTemplate initialization="video_0/init.mp4" media="video_0/media_$Number$.m4s" startNumber="6" timescale="90000">
+          <SegmentTimeline>
+            <S t="2827920" d="540000" r="9"></S>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation sar="1:1" mimeType="video/mp4" bandwidth="209067" codecs="avc1.42c01e" height="360" id="2" width="640">
+        <SegmentTemplate initialization="video_1/init.mp4" media="video_1/media_$Number$.m4s" startNumber="6" timescale="90000">
+          <SegmentTimeline>
+            <S t="2827920" d="540000" r="9"></S>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" segmentAlignment="true" contentType="audio">
+      <Representation mimeType="audio/mp4" audioSamplingRate="48000" bandwidth="97888" codecs="mp4a.40.2" id="1">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+        <SegmentTemplate initialization="audio_0/init.mp4" media="audio_0/media_$Number$.m4s" startNumber="7" timescale="90000">
+          <SegmentTimeline>
+            <S t="2827440" d="540000" r="9"></S>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation mimeType="audio/mp4" audioSamplingRate="48000" bandwidth="97888" codecs="mp4a.40.2" id="3">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+        <SegmentTemplate initialization="audio_1/init.mp4" media="audio_1/media_$Number$.m4s" startNumber="7" timescale="90000">
+          <SegmentTimeline>
+            <S t="2827440" d="540000" r="9"></S>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <UTCTiming value="https://time.akamai.com/?iso"></UTCTiming>
+</MPD>

--- a/mpd/mpd_read_write.go
+++ b/mpd/mpd_read_write.go
@@ -43,7 +43,7 @@ func Read(r io.Reader) (*MPD, error) {
 // path - Output path to write the manifest to.
 func (m *MPD) WriteToFile(path string) error {
 	// Open the file to write the XML to
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0666)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
 		return err
 	}

--- a/mpd/mpd_read_write_test.go
+++ b/mpd/mpd_read_write_test.go
@@ -382,3 +382,27 @@ func TestWriteToFileInvalidFilePath(t *testing.T) {
 	err := m.WriteToFile("")
 	require.NotNil(t, err)
 }
+
+func TestWriteToFileTruncate(t *testing.T) {
+	out := "test-truncate.mpd"
+
+	m, err := ReadFromFile("fixtures/truncate.mpd")
+	require.NoError(t, err)
+
+	err = m.WriteToFile(out)
+	require.NoError(t, err)
+
+	defer os.Remove(out)
+
+	xmlStr := testfixtures.LoadFixture(out)
+	testfixtures.CompareFixture(t, "fixtures/truncate.mpd", xmlStr)
+
+	m, err = ReadFromFile("fixtures/truncate_short.mpd")
+	require.NoError(t, err)
+
+	err = m.WriteToFile(out)
+	require.NoError(t, err)
+
+	xmlStr = testfixtures.LoadFixture(out)
+	testfixtures.CompareFixture(t, "fixtures/truncate_short.mpd", xmlStr)
+}


### PR DESCRIPTION
When writing to a file, it is opened without truncating, so writing to the same file multiple times can result in an invalid MPD if a subsequent write was smaller than a previous.