### PR TITLE
make Period.Start a pointer for optional 0 value support

### DIFF
--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -78,7 +78,7 @@ type MPD struct {
 type Period struct {
 	ID              string           `xml:"id,attr,omitempty"`
 	Duration        Duration         `xml:"duration,attr,omitempty"`
-	Start           Duration         `xml:"start,attr,omitempty"`
+	Start           *Duration        `xml:"start,attr,omitempty"`
 	BaseURL         string           `xml:"BaseURL,omitempty"`
 	SegmentBase     *SegmentBase     `xml:"SegmentBase,omitempty"`
 	SegmentList     *SegmentList     `xml:"SegmentList,omitempty"`

--- a/mpd/mpd_read_write_test.go
+++ b/mpd/mpd_read_write_test.go
@@ -68,6 +68,27 @@ func TestNewDynamicMPDLiveWriteToString(t *testing.T) {
 	require.EqualString(t, expectedXML, xmlStr)
 }
 
+func TestNewDynamicMPDLiveWithPeriodStartWriteToString(t *testing.T) {
+	m := NewDynamicMPD(DASH_PROFILE_LIVE, VALID_AVAILABILITY_START_TIME, VALID_MIN_BUFFER_TIME,
+		AttrMediaPresentationDuration(VALID_MEDIA_PRESENTATION_DURATION),
+		AttrMinimumUpdatePeriod(VALID_MINIMUM_UPDATE_PERIOD))
+
+	// Set first period start time to PT0S
+	p := m.GetCurrentPeriod()
+	start := Duration(time.Duration(0))
+	p.Start = &start
+
+	xmlStr, err := m.WriteToString()
+	require.NoError(t, err)
+	expectedXML := `<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S" availabilityStartTime="1970-01-01T00:00:00Z" minimumUpdatePeriod="PT5S">
+  <Period start="PT0S"></Period>
+  <UTCTiming></UTCTiming>
+</MPD>
+`
+	require.EqualString(t, expectedXML, xmlStr)
+}
+
 func TestNewMPDOnDemandWriteToString(t *testing.T) {
 	m := NewMPD(DASH_PROFILE_ONDEMAND, VALID_MEDIA_PRESENTATION_DURATION, VALID_MIN_BUFFER_TIME)
 


### PR DESCRIPTION
In ISO/IEC 23009-1:2014(E) Section 5.3.2.1

>If (i) @start attribute is absent, and (ii) the previous Period element does not contains a @duration attribute or the Period element is the first in the MPD, and (iii) the MPD@type is 'dynamic', then this Period is an Early Available Period (see below for details).

Since `Period.Start` is not a pointer and has `omitempty` a start of `PT0S` for the first period was not being written into the mpd. This is causing parsing errors in `dynamic` manifests because Dashjs and Exo Player treat it as an Early Available Period.

I did not think removing `omitempty` was the right call here because `Period@start` is an optional attribute, however, sometimes we need the value to be `0`, so I changed `Period.Start` to be a pointer so we can omit empty when the pointer is `nil`. i understand this is a breaking change so I'm open to other suggestions if we want to do this in a more backwards compatible way. 