### PR TITLE
add support for EventStreams

### DIFF
--- a/mpd/events.go
+++ b/mpd/events.go
@@ -7,7 +7,7 @@ type EventStream struct {
 	SchemeIDURI *string  `xml:"schemeIdUri,attr"`
 	Value       *string  `xml:"value,attr,omitempty"`
 	Timescale   *int64   `xml:"timescale,attr"`
-	Events      []*Event `xml:"Event,omitempty"`
+	Events      []Event  `xml:"Event,omitempty"`
 }
 
 type Event struct {

--- a/mpd/events.go
+++ b/mpd/events.go
@@ -1,0 +1,18 @@
+package mpd
+
+import "encoding/xml"
+
+type EventStream struct {
+	XMLName     xml.Name `xml:"EventStream"`
+	SchemeIDURI *string  `xml:"schemeIdUri,attr"`
+	Value       *string  `xml:"value,attr,omitempty"`
+	Timescale   *int64   `xml:"timescale,attr"`
+	Events      []*Event `xml:"Event,omitempty"`
+}
+
+type Event struct {
+	XMLName          xml.Name `xml:"Event"`
+	ID               *string  `xml:"id,attr,omitempty"`
+	PresentationTime *int64   `xml:"presentationTime,attr,omitempty"`
+	Duration         *int64   `xml:"duration,attr,omitempty"`
+}

--- a/mpd/events_test.go
+++ b/mpd/events_test.go
@@ -22,19 +22,19 @@ func newEventStreamMPD() *MPD {
 	)
 	p := m.GetCurrentPeriod()
 
-	es := &EventStream{
+	es := EventStream{
 		SchemeIDURI: ptrs.Strptr(VALID_EVENT_STREAM_SCHEME_ID_URI),
 		Value:       ptrs.Strptr(VALID_EVENT_STREAM_VALUE),
 		Timescale:   ptrs.Int64ptr(VALID_EVENT_STREAM_TIMESCALE),
 	}
 
-	e0 := &Event{
+	e0 := Event{
 		ID:               ptrs.Strptr("event-0"),
 		PresentationTime: ptrs.Int64ptr(100),
 		Duration:         ptrs.Int64ptr(50),
 	}
 
-	e1 := &Event{
+	e1 := Event{
 		ID:               ptrs.Strptr("event-1"),
 		PresentationTime: ptrs.Int64ptr(200),
 		Duration:         ptrs.Int64ptr(50),

--- a/mpd/events_test.go
+++ b/mpd/events_test.go
@@ -1,0 +1,66 @@
+package mpd
+
+import (
+	"testing"
+
+	"github.com/zencoder/go-dash/helpers/ptrs"
+	"github.com/zencoder/go-dash/helpers/require"
+	"github.com/zencoder/go-dash/helpers/testfixtures"
+)
+
+const (
+	VALID_EVENT_STREAM_SCHEME_ID_URI       = "urn:example:eventstream"
+	VALID_EVENT_STREAM_VALUE               = "eventstream"
+	VALID_EVENT_STREAM_TIMESCALE     int64 = 10
+)
+
+func newEventStreamMPD() *MPD {
+	m := NewDynamicMPD(
+		DASH_PROFILE_LIVE,
+		VALID_AVAILABILITY_START_TIME,
+		VALID_MIN_BUFFER_TIME,
+	)
+	p := m.GetCurrentPeriod()
+
+	es := &EventStream{
+		SchemeIDURI: ptrs.Strptr(VALID_EVENT_STREAM_SCHEME_ID_URI),
+		Value:       ptrs.Strptr(VALID_EVENT_STREAM_VALUE),
+		Timescale:   ptrs.Int64ptr(VALID_EVENT_STREAM_TIMESCALE),
+	}
+
+	e0 := &Event{
+		ID:               ptrs.Strptr("event-0"),
+		PresentationTime: ptrs.Int64ptr(100),
+		Duration:         ptrs.Int64ptr(50),
+	}
+
+	e1 := &Event{
+		ID:               ptrs.Strptr("event-1"),
+		PresentationTime: ptrs.Int64ptr(200),
+		Duration:         ptrs.Int64ptr(50),
+	}
+
+	es.Events = append(es.Events, e0, e1)
+	p.EventStreams = append(p.EventStreams, es)
+
+	return m
+}
+
+func TestEventStreamsWriteToString(t *testing.T) {
+	m := newEventStreamMPD()
+
+	got, err := m.WriteToString()
+	require.NoError(t, err)
+
+	testfixtures.CompareFixture(t, "fixtures/events.mpd", got)
+}
+
+func TestReadEventStreams(t *testing.T) {
+	m, err := ReadFromFile("fixtures/events.mpd")
+	require.NoError(t, err)
+
+	got, err := m.WriteToString()
+	require.NoError(t, err)
+
+	testfixtures.CompareFixture(t, "fixtures/events.mpd", got)
+}

--- a/mpd/fixtures/events.mpd
+++ b/mpd/fixtures/events.mpd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" minBufferTime="PT1.97S" availabilityStartTime="1970-01-01T00:00:00Z">
+  <Period>
+    <EventStream schemeIdUri="urn:example:eventstream" value="eventstream" timescale="10">
+      <Event id="event-0" presentationTime="100" duration="50"></Event>
+      <Event id="event-1" presentationTime="200" duration="50"></Event>
+    </EventStream>
+  </Period>
+  <UTCTiming></UTCTiming>
+</MPD>

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -92,6 +92,7 @@ type Period struct {
 	SegmentList     *SegmentList     `xml:"SegmentList,omitempty"`
 	SegmentTemplate *SegmentTemplate `xml:"SegmentTemplate,omitempty"`
 	AdaptationSets  []*AdaptationSet `xml:"AdaptationSet,omitempty"`
+	EventStreams    []*EventStream   `xml:"EventStream,omitempty"`
 }
 
 type DescriptorType struct {

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -92,7 +92,7 @@ type Period struct {
 	SegmentList     *SegmentList     `xml:"SegmentList,omitempty"`
 	SegmentTemplate *SegmentTemplate `xml:"SegmentTemplate,omitempty"`
 	AdaptationSets  []*AdaptationSet `xml:"AdaptationSet,omitempty"`
-	EventStreams    []*EventStream   `xml:"EventStream,omitempty"`
+	EventStreams    []EventStream    `xml:"EventStream,omitempty"`
 }
 
 type DescriptorType struct {


### PR DESCRIPTION
I opted to not add support for the `xlink:href` and `xlink:actuate` attributes for `EventStream` mainly because I was trying to do it in a clean way to support all elements that have the `xlink` attributes (`Period`,`AdaptationSet`,`EventStream`,`SegmentList`), using an embedded struct, but due to some issues with the way marshaling namespaced xml attributes works, I was trying to do something similar to the `ContentProtectMarshal` struct go-dash uses. However, since the `xlink` is not meant to be an element, but just attributes on the embedded struct, it wouldn't work quite the same. I decided it was better to tackle that problem separately rather than bundle it into this PR.