### PR TITLE
EssentialProperty should be an element not an attribute

### DIFF
--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -119,7 +119,7 @@ type CommonAttributesAndElements struct {
 	FramePacking              *DescriptorType       `xml:"framePacking,attr"`
 	AudioChannelConfiguration *DescriptorType       `xml:"audioChannelConfiguration,attr"`
 	ContentProtection         []ContentProtectioner `xml:"ContentProtection,omitempty"`
-	EssentialProperty         *DescriptorType       `xml:"essentialProperty,attr"`
+	EssentialProperty         *DescriptorType       `xml:"EssentialProperty,omitempty"`
 	SupplementalProperty      *DescriptorType       `xml:"supplmentalProperty,attr"`
 	InbandEventStream         *DescriptorType       `xml:"inbandEventStream,attr"`
 }


### PR DESCRIPTION
Small change to conform to the DASH [schema](https://github.com/Dash-Industry-Forum/MPEG-Conformance-and-reference-source/blob/master/conformance/MPDValidator/schemas/DASH-MPD.xsd#L24) 