### PR TITLE
Lowercase scheme IDs for content protection

### DIFF
--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -133,7 +133,7 @@ func (as *contentProtections) UnmarshalXML(d *xml.Decoder, start xml.StartElemen
 	var scheme string
 	for _, a := range start.Attr {
 		if a.Name.Local == "schemeIdUri" {
-			scheme = a.Value
+			scheme = strings.ToLower(a.Value)
 			break
 		}
 	}


### PR DESCRIPTION
We are using this library in our software to manipulate DASH manifests created by Unified Streaming Packager (https://www.unified-streaming.com/products/unified-packager). That packager puts content protection IDs in uppercase, but this library only checks for lowercase IDs, so we were losing the `<cenc:pssh>` block in the final output as the content protection blocks were being treated as generic.

This change forces content protection IDs to lowercase so the matching will succeed regardless of case. We tested this in our workflow and everything works as expected (i.e. the `<cenc:pssh>` block is not lost).