### PR TITLE
adding missing BaseURL to AdaptationSet as per specs

### DIFF
--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -191,6 +191,7 @@ type AdaptationSet struct {
 	Representations    []*Representation `xml:"Representation,omitempty"`
 	AccessibilityElems []*Accessibility  `xml:"Accessibility,omitempty"`
 	Label              *string           `xml:"label,attr"`
+	BaseURL            []string          `xml:"BaseURL,omitempty"`
 }
 
 func (as *AdaptationSet) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {


### PR DESCRIPTION
Examples such as this one: https://testassets.dashif.org/#testvector/details/590086c77459f8cb201b8d12 sets a baseURL value all the way down to the AdaptationSet, this PR adds that value so it can be parsed out properly if available without changing the manifest generation logic.