### PR TITLE
fix(mpd): emit AdaptationSet Label before Role and Representation

### DIFF
--- a/mpd/fixtures/hbbtv_profile.mpd
+++ b/mpd/fixtures/hbbtv_profile.mpd
@@ -34,10 +34,10 @@
       <Representation bandwidth="2780732" codecs="avc1.4d401f" frameRate="30000/1001" height="720" id="1500" width="1280"></Representation>
     </AdaptationSet>
     <AdaptationSet mimeType="text/vtt" id="7357" lang="en">
+      <Label>Subtitle (En)</Label>
       <Representation bandwidth="256" id="subtitle_en">
         <BaseURL>http://example.com/content/sintel/subtitles/subtitles_en.vtt</BaseURL>
       </Representation>
-      <Label>Subtitle (En)</Label>
     </AdaptationSet>
   </Period>
 </MPD>

--- a/mpd/fixtures/live_profile.mpd
+++ b/mpd/fixtures/live_profile.mpd
@@ -32,10 +32,10 @@
       <Representation bandwidth="2780732" codecs="avc1.4d401f" frameRate="30000/1001" height="720" id="1500" width="1280"></Representation>
     </AdaptationSet>
     <AdaptationSet mimeType="text/vtt" id="7357" lang="en">
+      <Label>Subtitle (En)</Label>
       <Representation bandwidth="256" id="subtitle_en">
         <BaseURL>http://example.com/content/sintel/subtitles/subtitles_en.vtt</BaseURL>
       </Representation>
-      <Label>Subtitle (En)</Label>
     </AdaptationSet>
   </Period>
 </MPD>

--- a/mpd/fixtures/live_profile_dynamic.mpd
+++ b/mpd/fixtures/live_profile_dynamic.mpd
@@ -32,10 +32,10 @@
       <Representation bandwidth="2780732" codecs="avc1.4d401f" frameRate="30000/1001" height="720" id="1500" width="1280"></Representation>
     </AdaptationSet>
     <AdaptationSet mimeType="text/vtt" id="7357" lang="en">
+      <Label>Subtitle (En)</Label>
       <Representation bandwidth="256" id="subtitle_en">
         <BaseURL>http://example.com/content/sintel/subtitles/subtitles_en.vtt</BaseURL>
       </Representation>
-      <Label>Subtitle (En)</Label>
     </AdaptationSet>
   </Period>
   <UTCTiming></UTCTiming>

--- a/mpd/fixtures/live_profile_multi_base_url.mpd
+++ b/mpd/fixtures/live_profile_multi_base_url.mpd
@@ -35,10 +35,10 @@
       <Representation bandwidth="2780732" codecs="avc1.4d401f" frameRate="30000/1001" height="720" id="1500" width="1280"></Representation>
     </AdaptationSet>
     <AdaptationSet mimeType="text/vtt" id="7357" lang="en">
+      <Label>Subtitle (En)</Label>
       <Representation bandwidth="256" id="subtitle_en">
         <BaseURL>http://example.com/content/sintel/subtitles/subtitles_en.vtt</BaseURL>
       </Representation>
-      <Label>Subtitle (En)</Label>
     </AdaptationSet>
   </Period>
 </MPD>

--- a/mpd/fixtures/ondemand_profile.mpd
+++ b/mpd/fixtures/ondemand_profile.mpd
@@ -41,10 +41,10 @@
       </Representation>
     </AdaptationSet>
     <AdaptationSet mimeType="text/vtt" id="7357" lang="en">
+      <Label>Subtitle (En)</Label>
       <Representation bandwidth="256" id="subtitle_en">
         <BaseURL>http://example.com/content/sintel/subtitles/subtitles_en.vtt</BaseURL>
       </Representation>
-      <Label>Subtitle (En)</Label>
     </AdaptationSet>
   </Period>
 </MPD>

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -184,13 +184,13 @@ type AdaptationSet struct {
 	MinHeight          *string           `xml:"minHeight,attr"`
 	MaxHeight          *string           `xml:"maxHeight,attr"`
 	ContentType        *string           `xml:"contentType,attr"`
+	Labels             []string          `xml:"Label,omitempty"`
 	Roles              []*Role           `xml:"Role,omitempty"`
 	SegmentBase        *SegmentBase      `xml:"SegmentBase,omitempty"`
 	SegmentList        *SegmentList      `xml:"SegmentList,omitempty"`
 	SegmentTemplate    *SegmentTemplate  `xml:"SegmentTemplate,omitempty"` // Live Profile Only
 	Representations    []*Representation `xml:"Representation,omitempty"`
 	AccessibilityElems []*Accessibility  `xml:"Accessibility,omitempty"`
-	Labels             []string          `xml:"Label,omitempty"`
 	BaseURL            []string          `xml:"BaseURL,omitempty"`
 }
 


### PR DESCRIPTION
Reorder AdaptationSet struct fields so encoding/xml writes `<Label>` before `<Role>,` `<SegmentTemplate>,` and `<Representation>,` matching DASH-MPD schema element sequence. Update golden fixtures for subtitle adaptation sets.